### PR TITLE
Add RFC for Grid Product

### DIFF
--- a/0000-product.md
+++ b/0000-product.md
@@ -24,11 +24,11 @@ field)._
 [motivation]: #motivation
 
 The Grid Product implementation is designed for sharing product master data
-between participants. Product is a near universal concept within supply chains
+between participants. Product is a near universal concept within supply chain
 solutions and would naturally be one of the highest areas of re-use across Grid
 applications.
 
-The design will address use cases including:
+The desgn will address use cases including:
 
 - Sharing of Product master data across a network
 - Including Product in other business transactions (track and trace events,
@@ -124,7 +124,7 @@ Schema Transaction Family and are restricted to the fields and rules of the GS1
 Product schema.  Transactions which are responsible for setting product state
 values must ensure that the properties conform with the requirements of the GS1
 Product Property Schema.
-sadfds
+
 ``` 
 message Product { 
     enum ProductNamespace { 

--- a/0000-product.md
+++ b/0000-product.md
@@ -81,10 +81,8 @@ are supported:
   state.
 * ProductDelete - remove a Product from state.
 
-*Disclaimer: ProductDelete does not remove the record of existance of a product.
-The history and record of existance of that product will remain. This is simply
-a mechanism to free up memory in state when it is known that a product will no
-longer be in existance.*
+*Disclaimer: ProductDelete is a potentially hazardous operation and needs to be 
+done with care. 
 
 ## Permissions
 
@@ -275,15 +273,19 @@ Validation requirements:
 belong to an organization in Pike state, otherwise the transaction is invalid.
 * The agent must have the permission can_create_product for the organization,
 otherwise the transaction is invalid.
-* If the product_namespace is GS1, the organization must contain a GS1 Company
-
-Prefix in its metadata (gs1_company_prefixes), and the prefix must match the company prefix in the product_id, which is a GTIN if GS1, otherwise the
+* If the product_namespace is GS1, the organization must contain a GS1 Company 
+Prefix in its metadata (gs1_company_prefixes), and the prefix must match the 
+company prefix in the product_id, which is a GTIN if GS1, otherwise the
 transaction is invalid.  
-* The properties must be valid for the product_namespace. For example, if the product is GS1 product, its properties must only contain properties that are includedin the GS1 Schema. If it includes a property not in the GS1 Schema the transaction is invalid.  
+* The properties must be valid for the product_namespace. For example, if the 
+product is GS1 product, its properties must only contain properties that are 
+included in the GS1 Schema. If it includes a property not in the GS1 Schema 
+the transaction is invalid.  
 
 _The base GS1 schema will be defined in a future RFC._
 
-If all requirements are met, the transaction will be accepted, the batch will be written to a block, and the product will be created in state.
+If all requirements are met, the transaction will be accepted, the batch will 
+be written to a block, and the product will be created in state.
 
 The inputs for ProductCreateAction must include:
 
@@ -321,10 +323,14 @@ Validation requirements:
 * If a product with product_id does not exist the transaction is invalid.  
 * The signer of the transaction must be an agent in the Pike state and must
 belong to an organization in Pike state, otherwise the transaction is invalid.
-* The owner in the product must match the organization that the agent belongs to, otherwise the transaction is invalid.  
+* The owner in the product must match the organization that the agent belongs to, 
+* otherwise the transaction is invalid.  
 * The agent must have the permission can_update_product for the organization,
 otherwise the transaction is invalid.
-* The new properties must be valid for the product_namespace.  For example, if the product is GS1 product, its properties must only contain properties that are included in the GS1 Schema. If it includes a property not in the GS1 Scheme the transaction is invalid.
+* The new properties must be valid for the product_namespace.  For example, if the 
+product is GS1 product, its properties must only contain properties that are 
+included in the GS1 Schema. If it includes a property not in the GS1 Scheme the 
+transaction is invalid.
   
 _The base GS1 schema will be defined in a future RFC._
 
@@ -372,8 +378,10 @@ Validation requirements:
 * If a product with product_id does not exist the transaction is invalid.  
 * The signer of the transaction must be an agent in the Pike state and must
 belong to an organization in Pike state, otherwise the transaction is invalid.
-* The owner in the product must match the organization that the agent belongs to, otherwise the transaction is invalid.  
-* The agent must have the permission “can_delete_product” for the organization otherwise the transaction is invalid.
+* The owner in the product must match the organization that the agent belongs to, 
+  otherwise the transaction is invalid.  
+* The agent must have the permission “can_delete_product” for the organization 
+  otherwise the transaction is invalid.
 
 The inputs for ProductDeleteAction must include:
 

--- a/0000-product.md
+++ b/0000-product.md
@@ -15,7 +15,7 @@ and familiarity, Grid support feels natural.  Additional implementations of
 Product for specialized industries or use cases may derive from or extend this
 implementation.
 
-_For the base implementation of a product on grid, there will be 4 fields. A
+_For the base implementation of a product on Grid, there will be 4 fields. A
 product_id, a product_namespace, an owner, and properties (a repeated key-value
 field)._
 
@@ -367,7 +367,7 @@ message ProductDeleteAction {
 } 
 ```
 
-If the grid setting grid.product.allow_delete is set to false, this transaction
+If the Grid setting `grid.product.allow_delete` is set to `false`, this transaction
 is invalid. The default value for grid.product.allow_delete is true. This
 setting is stored using the Sawtooth Settings smart contract, more information
 can be found
@@ -427,7 +427,7 @@ The GS1 Company Prefix will be stored in the metadata under
 
 Solving how to properly provide GS1 Company Prefixes to a Pike Organization will
 be solved in a future RFC. This future RFC should integrate the concepts of GLN
-and the smart contract associated with grid gs1 product should be updated to
+and the smart contract associated with Grid gs1 product should be updated to
 reflect that integration.  `
 
 Trade items can include non-material goods, such as services, which will also
@@ -444,7 +444,7 @@ heterogeneous nature, with another GS1 identifier (SSCC).
   services (GSRN) OUT
 
 To expand the product schema to support all GS1 properties as well as keeping it
-all organized, there will need to be some refactoring done at the grid primitive
+all organized, there will need to be some refactoring done at the Grid primitive
 level to support lists in the schema.
 
 This implementation does not account for transfer-of-ownership scenarios, and

--- a/0000-product.md
+++ b/0000-product.md
@@ -6,28 +6,35 @@
 [summary]: #summary
 
 
-This RFC proposes a generic and extensible framework for a Hyperledger Grid Product entity as well as a more specific - and fully encapsulated - GS1 compliant Product.
+This RFC proposes a generic and extensible framework for a Hyperledger Grid
+Product entity as well as a more specific - and fully encapsulated - GS1
+compliant Product.
 
 GS1 is a widely used data standard in enterprises and, given that
 positioning and familiarity, Grid support feels natural.  Additional
 implementations of Product for specialized industries or use cases may derive
-from or extend this implementation. 
+from or extend this implementation.
 
 _For the base implementation of a product
-on grid, there will be 4 fields. A product_id, a product_type, an owner, and properties (a repeated key-value field)._
+on grid, there will be 4 fields. A product_id, a product_type, an owner, and
+properties (a repeated key-value field)._
 
 
 # Motivation
 [motivation]: #motivation
 
 The Grid Product implementation is designed for sharing product master data
-between participants. Product is a near universal concept within supply chains solutions and would naturally be one of the highest areas of re-use across Grid applications. 
+between participants. Product is a near universal concept within supply chains
+solutions and would naturally be one of the highest areas of re-use across Grid
+applications.
 
 The design will address use cases including:
 
 - Sharing of Product master data across a network
-- Including Product in other business transactions (track and trace events, purchases, sales, etc)
-- Enriching UX experiences by including additional attribution of a Product such as names or descriptions
+- Including Product in other business transactions (track and trace events,
+purchases, sales, etc)
+- Enriching UX experiences by including additional attribution of a Product
+such as names or descriptions
 
 It is also useful to use product information as
 auxiliary data in other supply chain solutions.  For example, in track and
@@ -60,7 +67,8 @@ component of Grid).
 
 A product has one or more **properties**.  Properties are described in the Grid
 Primitives RFC.  A *property namespace* contains multiple *property
-schemas*.  A property schema associates a name (such as “length”) with a data type
+schemas*.  A property schema associates a name (such as “length”) with a data
+type
 (such as integer).  GS1 products may only include properties defined in the GS1
 product property namespace.
 
@@ -100,7 +108,8 @@ references to these products and deleting them could leave dangling references.
 Creation of a resuable gtin validation function to programmatically express the
 equation used to validate a GTIN. It validates gtin format to avoid mistype
 errors similar to a credit card validation. It's implemented as an extensible
-function such that further validation steps can be added, if needed.  Check digit validation:
+function such that further validation steps can be added, if needed.  Check
+digit validation:
 (https://www.gs1.org/services/how-calculate-check-digit-manually)
 
 
@@ -132,7 +141,8 @@ message Product {
 }
 ```
 
-The GS1 GTIN is an identifier (product_id) used to identify trade items.  A GTIN is the data
+The GS1 GTIN is an identifier (product_id) used to identify trade items.  A
+GTIN is the data
 transmitted from a barcode scan and is made up of a company prefix (or GS1-8
 prefix) and item reference.  We will initially support GTIN-12, GTIN-13, and
 GTIN-14. (GTIN-8 may be supported in the future.) The GS1 GTIN specification is

--- a/0000-product.md
+++ b/0000-product.md
@@ -107,9 +107,8 @@ references to these products and deleting them could leave dangling references.
 Creation of a resuable gtin validation function to programmatically express the
 equation used to validate a GTIN. It validates gtin format to avoid mistype
 errors similar to a credit card validation. It's implemented as an extensible
-function such that further validation steps can be added, if needed.  Check
-digit validation:
-(https://www.gs1.org/services/how-calculate-check-digit-manually)
+function such that further validation steps can be added, if needed. For details on the equation see: [Check
+digit validation](https://www.gs1.org/services/how-calculate-check-digit-manually).
 
 
 # Reference-level explanation
@@ -261,21 +260,15 @@ message ProductCreateAction {
 }
 ```
 
-If a product with product_id already exists the transaction is invalid.
+Validation requirements:
 
-The signer of the transaction must be an agent in the Pike state and must
+* If a product with product_id already exists the transaction is invalid.
+* The signer of the transaction must be an agent in the Pike state and must
 belong to an organization in Pike state, otherwise the transaction is invalid.
 The agent must have the permission can_create_product for the organization,
 otherwise the transaction is invalid.
-
-If the product_namespace is GS1, the organization must contain a GS1 Company Prefix
-in its metadata (gs1_company_prefixes), and the prefix must match the company
-prefix in the product_id, which is a gtin if GS1, otherwise the transaction is
-invalid.
-
-The properties must be valid for the product_namespace. For example, if the product
-is GS1 product, its properties must only contain properties that are included
-in the GS1 Schema. If it includes a property not in the GS1 Schema the
+* If the product_namespace is GS1, the organization must contain a GS1 Company Prefix in its metadata (gs1_company_prefixes), and the prefix must match the company prefix in the product_id, which is a gtin if GS1, otherwise the transaction is invalid.
+* The properties must be valid for the product_namespace. For example, if the productis GS1 product, its properties must only contain properties that are includedin the GS1 Schema. If it includes a property not in the GS1 Schema the
 transaction is invalid.  _The base GS1 schema will be defined in a future RFC._
 
 The product will be set in state.
@@ -312,19 +305,15 @@ message ProductUpdateAction {
 }
 ```
 
-If a product with product_id does not exist the transaction is invalid.
+Validation requirements:
 
-The signer of the transaction must be an agent in the Pike state and must
+* If a product with product_id does not exist the transaction is invalid.
+* The signer of the transaction must be an agent in the Pike state and must
 belong to an organization in Pike state, otherwise the transaction is invalid.
-
-The owner in the product must match the organization that the agent belongs to,
+* The owner in the product must match the organization that the agent belongs to, otherwise the transaction is invalid.
+* The agent must have the permission can_update_prouduct for the organization,
 otherwise the transaction is invalid.
-
-The agent must have the permission can_update_prouduct for the organization,
-otherwise the transaction is invalid.
-
-The new properties must be valid for the product_namespace. For example, if the
-product is GS1 product, its properties must only contain properties that are
+* The new properties must be valid for the product_namespace. For example, if theproduct is GS1 product, its properties must only contain properties that are
 included in the GS1 Schema. If it includes a property not in the GS1 Scheme the
 transaction is invalid.
 
@@ -364,18 +353,15 @@ message ProductDeleteAction {
 If the grid setting grid.product.allow_delete is set to false, this transaction
 is invalid. The default value for grid.product.allow_delete is true. This
 setting is stored using the Sawtooth Settings smart contract, more information
-can be found here:
-https://sawtooth.hyperledger.org/docs/core/releases/latest/transaction_family_specifications/settings_transaction_family.html
+can be found [here](https://sawtooth.hyperledger.org/docs/core/releases/latest/transaction_family_specifications/settings_transaction_family.html).
 
-If a product with product_id does not exist the transaction is invalid.
+Validation requirements:
 
-The signer of the transaction must be an agent in the Pike state and must
+* If a product with product_id does not exist the transaction is invalid.
+* The signer of the transaction must be an agent in the Pike state and must
 belong to an organization in Pike state, otherwise the transaction is invalid.
-
-The owner in the product must match the organization that the agent belongs to,
-otherwise the transaction is invalid.
-
-The agent must have the permission “can_delete_product” for the organization,
+* The owner in the product must match the organization that the agent belongs to, otherwise the transaction is invalid.
+* The agent must have the permission “can_delete_product” for the organization,
 otherwise the transaction is invalid.
 
 The inputs for ProductDeleteAction must include:

--- a/0000-product.md
+++ b/0000-product.md
@@ -1,0 +1,358 @@
+# Summary
+[summary]: #summary
+
+This RFC proposes a GS1-compatible implementation of Product for Hyperledger Grid. 
+GS1 is a widely used data standard in enterprises and, given that positioning and familiarity, Grid support feels natural. 
+Additional implementations of Product for specialized industries or use cases may derive from or extend this implementation.
+
+# Motivation
+[motivation]: #motivation
+
+The Grid Product implementation is designed for sharing product master data between participants. 
+It is also useful to use product information as auxiliary data in other supply chain solutions. 
+For example, in track and trace, the location and temperature of an item (an instance of a product) is stored. 
+When presenting this information later to a human user, it is useful to combine it with information about the product, such as the product’s name and description. 
+Therefore, Product becomes a reusable and important component within Grid.
+
+# Guide-Level Explanation
+[guide-level-explanation]: #guide-level-explanation
+
+## Entities
+
+A **__product__** is an archetype of an item that is transacted, traded, or referenced in a supply chain. 
+Each product has a **__product type__**. This RFC defines a single product type for GS1; a product of the GS1 product type is called a GS1 product. 
+Note that this design supports adding additional product types in the future.
+
+A product is referenced using a **__product identifier__**. 
+For GS1 products, the product identifier is a Global Trade Item Number (GTIN), which is part of the GS1 specifications.
+
+Each product has an **__owner__**, which is the identifier of the organization responsible for maintaining the product. 
+An **__agent__** acts on behalf of an organization, and all permissions are defined in terms of the actions agents can perform. 
+Organizations and agents are defined and managed by Pike (another component of Grid).
+
+A product has one or more **properties**. 
+Properties are described in the Grid Primitives RFC. 
+A **property namespace** contains multiple **property schema**. 
+A property schema associates a name (such as “length”) with a type (such as integer). 
+GS1 products may only include properties defined in the GS1 product property namespace.
+
+## Transactions
+Products are managed by submitting transactions to Hyperledger Grid, which will process them with the Grid Product smart contract. The following transactions are supported:
+
+* ProductCreate - create a Product and store it in state.
+* ProductUpdate - update (replace) the properties of a Product already in state.
+* ProductDelete - remove a Product from state.
+
+## Permissions
+Creation of GS1 products is restricted to agents acting on behalf of the organization that is associated with the GS1 company prefix encoded in the GTIN. 
+An organization must have the GS1 company prefix in the “gs1_company_prefixes” metadata field for its Pike organization. (Organization-level metadata will need to be implemented in Pike.) 
+When a product is created, its owning organization is stored with the project in an “owner” field.
+
+Updates to products is restricted to agents acting on behalf of the organization stored in the product’s owner field. 
+Only property fields can be updated. Product type, identifier, and owner fields are immutable. 
+
+Deletion of products is restricted to agents acting on behalf of the organization in the product’s owner field. 
+A setting will turn off deletion entirely, with the intent that it could be enabled/disabled by a Grid administrator. 
+Disabling delete is useful because external systems may have references to these products and deleting them could leave dangling references.
+
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+## State
+
+### Product Representation
+The primary object stored in state is “Product”, which consists of an identifier (GS1 GTIN), an owner (organization identifier compatible w/Pike), and a list of property name/value pairs. 
+The properties available are defined by the Grid Property Schema Transaction Family and are restricted to the fields and rules of the GS1 Product schema. 
+Transactions which are responsible for setting product state values must ensure that the properties conform with the requirements of the GS1 Product Property Schema.
+
+```
+message Product {
+    enum ProductType {
+        UNSET_TYPE = 0;
+        GS1 = 1;
+    }
+    ProductType product_type = 1;
+    string identifier = 2;
+    string owner = 3;
+    repeated PropertyValue properties = 4;
+}
+```
+
+The GS1 GTIN is an identifier used to identify trade items. 
+A GTIN is the data transmitted from a barcode scan and is made up of a company prefix (or GS1-8 prefix) and item reference. 
+We will initially support GTIN-12, GTIN-13, and GTIN-14. (GTIN-8 may be supported in the future.) 
+The GS1 GTIN specification is documented in section 3.3.2, Identification of a trade item (GTIN): AI (01), on page 140 of the **GS1 General Specification**: 
+https://www.gs1.org/sites/default/files/docs/barcodes/GS1_General_Specifications.pdf
+
+The GS1-8 prefix is a unique string of 3 digits, and the GS1 company prefix consists of 4-12 digits. 
+The GS1-8 prefixes is issued by the GS1 Global Office. The GS1-8 prefix is allocated to a GS1 member organization to issue the GTIN-8’s to other areas. 
+The GS1 company prefix can be issued by the GS1 Global Office or a member organization. Usually issued to a company itself.
+
+Also relevant is the GS1-8 Prefix or GS1 Company Prefix which namespaces the GTIN by issuing organization. 
+GS1 manages the master data for company prefixes. Owning companies issue their own GTINs within their prefixed namespace. 
+Details about GS1 Company Prefixes can be found in section 1.4.4, GS1 Company Prefix, on page 20 of the GS1 General Specifications.
+
+### Referencing Products
+Products are uniquely referenced by their product type and identifier. 
+For GS1, Products are referenced by the GTIN identifier. For example:
+```
+    get_gs1_product(GTIN)
+    set_gs1_product(GTIN, GS1Product)
+```
+
+### Product Addressing in the Merkle-Radix State System
+In order to uniquely locate GS1 products in the Merkle-Radix state system, an address must be constructed which identifies the storage location of the Product representation.
+
+All Grid addresses are prefixed by the 6-hex-character namespace prefix “621dee”,  
+Products are further prefixed under the Grid namespace with reserved enumerations of “02” (“00” and “01” being reserved for other purposes) indicating “Products” and an additional “01” indicating “GS1 Products”. 
+
+Therefore, all addresses starting with:
+```
+    “621dee” + “02” + “01”
+```
+are Grid GS1 Products identified by a GTIN and are expected to contain a Product representation which conforms with the GS1 product schema.
+
+GTIN formats consist of 14-digit “numeric strings” which include some amount of internal “0” padding depending on the specific GTIN format (GTIN-8, GTIN-12, GTIN-13, or GTIN-14). 
+After the 10-hex-characters that are consumed by the grid namespace prefix, the product, and GS1 prefixes, there are 60 hex characters remaining in the address. 
+The 14 digits of the GTIN can be left padded with 44-hex-character zeroes and right padded with 2-hex-character zeroes to accommodate potential future storage associated with the GS1 Product representation, 
+for example:
+
+```
+   “621dee” + “02” + “01” + “00000000000000000000000000000000000000000000” + 14-character “numeric string” GTIN + “00”
+```
+
+A full GS1 Product address using the example GTIN from https://www.gtin.info/ would therefore be:
+```
+    “621dee0201000000000000000000000000000000000000000000000001234560001200”
+```
+
+## Transaction Payload and Execution
+
+### ProductPayload Transaction
+
+ProductPayload contains an action enum and the associated action payload.
+This allows for the action payload to be dispatched to the appropriate logic.
+
+Only the defined actions are available and only one action payload should be
+defined in the ProductPayload.
+
+```
+message ProductPayload {
+    enum Actions {
+        UNSET_ACTION = 0;
+        PRODUCT_CREATE = 1;
+        PRODUCT_UPDATE = 2;
+        PRODUCT_DELETE = 3;
+    }
+
+    Action action = 1;
+
+    ProductCreateAction product_create = 2;
+    ProductUpdateAction product_update = 3;
+    ProductDeleteAction product_delete = 4;
+}
+```
+
+### ProductCreateAction
+
+ProductCreateAction adds a new product to state. The transaction should be submitted by an agent, 
+which is identified by its signing key, acting on behalf of the organization that corresponds to the owner in the create 
+transaction. (Organizations and agents are defined by the Pike smart contract.)
+
+```
+message ProductCreateAction {
+    enum ProductType {
+        UNSET_TYPE = 0;
+        GS1 = 1;
+    }
+    // product_type and identifier are used in deriving the state address
+    ProductType product_type = 1;
+    string identifier = 2;
+    string owner = 3;
+    repeated PropertyValues properties = 4;
+}
+```
+
+If a product with identifier already exists the transaction is invalid.
+
+The signer of the transaction must be an agent in the Pike state and must belong to an organization in Pike state, 
+otherwise the transaction is invalid.  The agent must have the permission can_create_product for the organization, 
+otherwise the transaction is invalid.
+
+If the product type is GS1, the organization must contain a GS1 Company Prefix in its metadata (gs1_company_prefixes), 
+and the prefix must match the company prefix in the identifier, which is a gtin if GS1, otherwise the transaction is invalid.
+
+The properties must be valid for the product type. For example, if the product is GS1 product, its properties must only 
+contain properties that are included in the GS1 Schema. If it includes a property not in the GS1 Scheme the transaction is invalid. 
+
+The product will be set in state.
+
+The inputs for ProductCreateAction must include:
+* Address of the Agent submitting the transaction
+* Address of the Organization the Product is being created for
+* Address of the Product Type Scheme the  product’s properties must match 
+* Address of the Product to be created
+
+The outputs for ProductCreateAction must include:
+* Address of the Product created
+
+### ProductUpdateAction
+
+ProductUpdateAction updates an existing product in state. The transaction should be submitted by an agent, identified by its signing key, acting on behalf of an organization that corresponds to the owner in the product being updated. (Organizations and agents are defined by the Pike smart contract.)
+```
+message ProductUpdateAction {
+    enum ProductType {
+        UNSET_TYPE = 0;
+        GS1 = 1;
+    }
+    // product_type and identifier are used in deriving the state address
+    ProductType product_type = 1;
+    string identifier = 2;
+    // this will replace all properties currently defined
+    repeated PropertyValues properties = 3;
+}
+```
+
+If a product with identifier does not exist the transaction is invalid.
+
+The signer of the transaction must be an agent in the Pike state and must belong to an organization in Pike state, otherwise the transaction is invalid.
+
+The owner in the product must match the organization that the agent belongs to, otherwise the transaction is invalid.
+
+The agent must have the permission can_update_prouduct for the organization, otherwise the transaction is invalid.
+
+The new properties must be valid for the product type. For example, if the product is GS1 product, its properties must only contain properties that are included in the GS1 Schema. If it includes a property not in the GS1 Scheme the transaction is invalid. 
+
+The properties in the product will be swapped for the new properties and the updated product will be set in state.
+
+The inputs for ProductUpdateAction must include:
+* Address of the Agent submitting the transaction
+* Address of the Organization the Product is being updated for
+* Address of the Product Type Scheme the product’s properties must match 
+* Address of the Product to be updated
+
+The outputs for ProductUpdateAction must include:
+* Address of the Product updated
+
+### ProductDeleteAction
+ProductDeleteAction removes an existing product from state. The transaction should be submitted by an agent, identified by its signing key, acting on behalf of the organization that corresponds to the org_id in the product being updated. (Organizations and agents are defined by the Pike smart contract.)
+```
+message ProductDeleteAction {
+    enum ProductType {
+        UNSET_TYPE = 0;
+        GS1 = 1;
+    }
+    // product_type and identifier are used in deriving the state address
+    ProductType product_type = 1;	
+    string identifier = 2;
+ }
+```
+If the grid setting grid.product.allow_delete is set to false, this transaction is invalid. The default value for grid.product.allow_delete is true.This setting is stored using the Sawtooth Settings smart contract, more information can be found here https://sawtooth.hyperledger.org/docs/core/releases/latest/transaction_family_specifications/settings_transaction_family.html
+
+If a product with identifier does not exist the transaction is invalid.
+
+The signer of the transaction must be an agent in the Pike state and must belong to an organization in Pike state, otherwise the transaction is invalid.
+
+The owner in the product must match the organization that the agent belongs to, otherwise the transaction is invalid.
+
+The agent must have the permission “can_delete_product” for the organization, otherwise the transaction is invalid.
+
+The inputs for ProductDeleteAction must include:
+* Address of the Agent submitting the transaction
+* Address of the Organization the Product is being deleted for
+* Address of the Product to be deleted
+
+The outputs for ProductUpdateAction must include:
+* Address of the Product to be deleted
+
+### Defined GS1 Properties
+An initial set of GS1 properties will be predefined within Grid. Each property will have a property definition of the following format:
+```
+PropertyDefinition(
+    name="<GSI Application Identifier>",
+    data_type=PropertyDefinition.DataType.STRING,
+    required=False,
+    description="A description of the GS1 data."
+)
+```
+
+The list of predefined properties from the GS1 Spec:
+
+| GS1 Application Identifier    | Description            | 
+| ------------- |:-------------:| 
+| 334                           | Area in Square metres  |
+| 353                           | Area in Square inches  |
+| 354                           | Area in Square feet    |
+| 355                           | Area in Square yards   |
+| 311                           | Length in metres       |
+| 341                           | Length in inches       |
+| 342                           | Length in feet         |
+| 343                           | Length in yards        |
+| 312                           | Width in metres        |
+| 324                           | Width in inches        |
+| 325                           | Width in feet          |
+| 326                           | Width in yards         |
+| 313                           | Height in meters       |
+| 327                           | Height in inches       |
+| 328                           | Height in feet         |
+| 329                           | Height in yards        |
+| 422                           | Country of Origin      |
+| 330                           | Gross weight           |
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Each GTIN format, except GTIN-8, contains an GS1 Company Prefix organizational identifier encoded into it, and this RFC duplicates the organization identification with a Grid-specific owner field to tie the product to organizations managed in Pike. In the future, it may be good to use the GTIN’s organizational identifier directly.
+
+Currently, Pike does not provide a place to store a GS1 Company Prefix, and the permissions around who is authorized to provide this prefix is complicated and not a direct extension of how Pike currently works. As such it is out of the scope of this RFC. 
+
+Instead, Pike’s organization definition will be extended to include metadata, similar to Agent’s metadata. Metadata is a Key,Value store of arbitrary data.  The GS1 Company Prefix will be stored in the metadata under “gs1_company_prefix”. 
+
+Solving how to properly provide GS1 Company Prefixes to a Pike Organization will be solved in a future RFC.
+
+Trade items can include non-material goods, such as services, which will also need to be represented within Grid. This is not covered by this RFC.
+
+To expand the product schema to support all GS1 app id’s as well as keeping it all organized, there will need to be some refactoring done at the grid primitive level to support lists in the schema. 
+
+Currently, we will **__exclude clothing, and furniture__** from the product properties. Keeping the focus on food items for the initial implementation of product.
+
+
+# Rationale and alternatives
+[alternatives]: #alternatives
+
+Starting with just capturing food items allows us to figure out the complexities associated with products in general. By starting with the GS1 standards/app identifiers for produce (food) products, we will be able to iterate and get it right for one product space before moving on to others. i.e. clothing, furniture, etc.
+
+Some details on products that can be used for a future iteration: 
+[GS1 Apparel and General Merchandise](https://www.gs1us.org/DesktopModules/Bring2mind/DMX/Download.aspx?Command=Core_Download&EntryId=1067&language=en-US&PortalId=0&TabId=134)
+
+### Clothing:
+Material content:  
+This element is used to indicate the material composition. This element is used in conjunction with the percentage.
+
+Material Percentage:  
+Net weight percentage of a product material of the first main material. The percentages must add up to 100.
+
+Material Percentage:  
+Net weight percentage of a product material of the first main material. The percentages must add up to 100.
+
+### Furniture:
+
+Number of pieces:     
+The total number of separately packaged components comprising a single trade item.
+
+Look at section 3.5.7 Packaging component number AI (243)
+
+
+# Prior Art
+[prior-art]: #prior-art
+
+[Pike Transaction Family Specification](https://github.com/hyperledger/sawtooth-sabre/blob/master/contracts/sawtooth-pike/docs/source/pike_transaction_family.rst)
+
+The Sawtooth Supply Chain mechanism to define field types.
+[Sawtooth Supply Chain Expanded Data Types](https://github.com/hyperledger/sawtooth-rfcs/blob/master/text/0013-supply-chain-expand-data-types.md)
+
+
+
+# Unresolved questions
+[unresolved]: #unresolved-questions

--- a/0000-product.md
+++ b/0000-product.md
@@ -5,20 +5,31 @@
 # Summary
 [summary]: #summary
 
-This RFC proposes a GS1-compatible implementation of Product for Hyperledger
-Grid.  GS1 is a widely used data standard in enterprises and, given that
+
+This RFC proposes a generic and extensible framework for a Hyperledger Grid Product entity as well as a more specific - and fully encapsulated - GS1 compliant Product.
+
+GS1 is a widely used data standard in enterprises and, given that
 positioning and familiarity, Grid support feels natural.  Additional
 implementations of Product for specialized industries or use cases may derive
-from or extend this implementation. _For the base implementation of a product
-on grid, there will be 4 fields. An identifier (gtin), a type (GS1), an owner
-(organization) and a repeated key-value field._
+from or extend this implementation. 
+
+_For the base implementation of a product
+on grid, there will be 4 fields. An identifier, a type, an owner, and a repeated key-value field._
 
 
 # Motivation
 [motivation]: #motivation
 
 The Grid Product implementation is designed for sharing product master data
-between participants.  It is also useful to use product information as
+between participants. Product is a near universal concept within supply chains solutions and would naturally be one of the highest areas of re-use across Grid applications. 
+
+The design will address use cases including:
+
+- Sharing of Product master data across a network
+- Including Product in other business transactions (track and trace events, purchases, sales, etc)
+- Enriching UX experiences by including additional attribution of a Product such as names or descriptions
+
+It is also useful to use product information as
 auxiliary data in other supply chain solutions.  For example, in track and
 trace, the location and temperature of an item (an instance of a product) is
 stored.  When presenting this information later to a human user, it is useful
@@ -114,7 +125,7 @@ message Product {
         UNSET_TYPE = 0;
         GS1 = 1;
     }
-    ProductType product_type = 1;
+    ProductType type = 1;
     string identifier = 2;
     string owner = 3;
     repeated PropertyValue properties = 4;
@@ -233,8 +244,8 @@ message ProductCreateAction {
         UNSET_TYPE = 0;
         GS1 = 1;
     }
-    // product_type and identifier are used in deriving the state address
-    ProductType product_type = 1;
+    // type and identifier are used in deriving the state address
+    ProductType type = 1;
     string identifier = 2;
     string owner = 3;
     repeated PropertyValues properties = 4;
@@ -284,8 +295,8 @@ message ProductUpdateAction {
         UNSET_TYPE = 0;
         GS1 = 1;
     }
-    // product_type and identifier are used in deriving the state address
-    ProductType product_type = 1;
+    // type and identifier are used in deriving the state address
+    ProductType type = 1;
     string identifier = 2;
     // this will replace all properties currently defined
     repeated PropertyValues properties = 4;
@@ -335,8 +346,8 @@ message ProductDeleteAction {
         UNSET_TYPE = 0;
         GS1 = 1;
     }
-    // product_type and identifier are used in deriving the state address
-    ProductType product_type = 1;
+    // type and identifier are used in deriving the state address
+    ProductType type = 1;
     string identifier = 2;
  }
 ```

--- a/0000-product.md
+++ b/0000-product.md
@@ -1,17 +1,25 @@
 # Summary
 [summary]: #summary
 
-This RFC proposes a GS1-compatible implementation of Product for Hyperledger Grid. 
-GS1 is a widely used data standard in enterprises and, given that positioning and familiarity, Grid support feels natural. 
-Additional implementations of Product for specialized industries or use cases may derive from or extend this implementation.
+This RFC proposes a GS1-compatible implementation of Product for Hyperledger
+Grid. 
+GS1 is a widely used data standard in enterprises and, given that positioning
+and familiarity, Grid support feels natural. 
+Additional implementations of Product for specialized industries or use cases
+may derive from or extend this implementation.
 
 # Motivation
 [motivation]: #motivation
 
-The Grid Product implementation is designed for sharing product master data between participants. 
-It is also useful to use product information as auxiliary data in other supply chain solutions. 
-For example, in track and trace, the location and temperature of an item (an instance of a product) is stored. 
-When presenting this information later to a human user, it is useful to combine it with information about the product, such as the product’s name and description. 
+The Grid Product implementation is designed for sharing product master data
+between participants. 
+It is also useful to use product information as auxiliary data in other supply
+chain solutions. 
+For example, in track and trace, the location and temperature of an item (an
+instance of a product) is stored. 
+When presenting this information later to a human user, it is useful to combine
+it with information about the product, such as the product’s name and
+description. 
 Therefore, Product becomes a reusable and important component within Grid.
 
 # Guide-Level Explanation
@@ -19,41 +27,62 @@ Therefore, Product becomes a reusable and important component within Grid.
 
 ## Entities
 
-A **__product__** is an archetype of an item that is transacted, traded, or referenced in a supply chain. 
-Each product has a **__product type__**. This RFC defines a single product type for GS1; a product of the GS1 product type is called a GS1 product. 
+A **__product__** is an archetype of an item that is transacted, traded, or
+referenced in a supply chain. 
+Each product has a **__product type__**. This RFC defines a single product type
+for GS1; a product of the GS1 product type is called a GS1 product. 
 Note that this design supports adding additional product types in the future.
 
 A product is referenced using a **__product identifier__**. 
-For GS1 products, the product identifier is a Global Trade Item Number (GTIN), which is part of the GS1 specifications.
+For GS1 products, the product identifier is a Global Trade Item Number (GTIN),
+which is part of the GS1 specifications.
 
-Each product has an **__owner__**, which is the identifier of the organization responsible for maintaining the product. 
-An **__agent__** acts on behalf of an organization, and all permissions are defined in terms of the actions agents can perform. 
-Organizations and agents are defined and managed by Pike (another component of Grid).
+Each product has an **__owner__**, which is the identifier of the organization
+responsible for maintaining the product. 
+An **__agent__** acts on behalf of an organization, and all permissions are
+defined in terms of the actions agents can perform. 
+Organizations and agents are defined and managed by Pike (another component of
+Grid).
 
 A product has one or more **properties**. 
 Properties are described in the Grid Primitives RFC. 
 A **property namespace** contains multiple **property schema**. 
-A property schema associates a name (such as “length”) with a type (such as integer). 
-GS1 products may only include properties defined in the GS1 product property namespace.
+A property schema associates a name (such as “length”) with a type (such as
+integer). 
+GS1 products may only include properties defined in the GS1 product property
+namespace.
 
 ## Transactions
-Products are managed by submitting transactions to Hyperledger Grid, which will process them with the Grid Product smart contract. The following transactions are supported:
+Products are managed by submitting transactions to Hyperledger Grid, which will
+process them with the Grid Product smart contract. The following transactions
+are supported:
 
 * ProductCreate - create a Product and store it in state.
-* ProductUpdate - update (replace) the properties of a Product already in state.
+* ProductUpdate - update (replace) the properties of a Product already in
+state.
 * ProductDelete - remove a Product from state.
 
 ## Permissions
-Creation of GS1 products is restricted to agents acting on behalf of the organization that is associated with the GS1 company prefix encoded in the GTIN. 
-An organization must have the GS1 company prefix in the “gs1_company_prefixes” metadata field for its Pike organization. (Organization-level metadata will need to be implemented in Pike.) 
-When a product is created, its owning organization is stored with the project in an “owner” field.
+Creation of GS1 products is restricted to agents acting on behalf of the
+organization that is associated with the GS1 company prefix encoded in the
+GTIN. 
+An organization must have the GS1 company prefix in the “gs1_company_prefixes”
+metadata field for its Pike organization. (Organization-level metadata will
+need to be implemented in Pike.) 
+When a product is created, its owning organization is stored with the project
+in an “owner” field.
 
-Updates to products is restricted to agents acting on behalf of the organization stored in the product’s owner field. 
-Only property fields can be updated. Product type, identifier, and owner fields are immutable. 
+Updates to products is restricted to agents acting on behalf of the
+organization stored in the product’s owner field. 
+Only property fields can be updated. Product type, identifier, and owner fields
+are immutable. 
 
-Deletion of products is restricted to agents acting on behalf of the organization in the product’s owner field. 
-A setting will turn off deletion entirely, with the intent that it could be enabled/disabled by a Grid administrator. 
-Disabling delete is useful because external systems may have references to these products and deleting them could leave dangling references.
+Deletion of products is restricted to agents acting on behalf of the
+organization in the product’s owner field. 
+A setting will turn off deletion entirely, with the intent that it could be
+enabled/disabled by a Grid administrator. 
+Disabling delete is useful because external systems may have references to
+these products and deleting them could leave dangling references.
 
 
 # Reference-level explanation
@@ -62,69 +91,98 @@ Disabling delete is useful because external systems may have references to these
 ## State
 
 ### Product Representation
-The primary object stored in state is “Product”, which consists of an identifier (GS1 GTIN), an owner (organization identifier compatible w/Pike), and a list of property name/value pairs. 
-The properties available are defined by the Grid Property Schema Transaction Family and are restricted to the fields and rules of the GS1 Product schema. 
-Transactions which are responsible for setting product state values must ensure that the properties conform with the requirements of the GS1 Product Property Schema.
+The primary object stored in state is “Product”, which consists of an
+identifier (GS1 GTIN), an owner (organization identifier compatible w/Pike),
+and a list of property name/value pairs. 
+The properties available are defined by the Grid Property Schema Transaction
+Family and are restricted to the fields and rules of the GS1 Product schema. 
+Transactions which are responsible for setting product state values must ensure
+that the properties conform with the requirements of the GS1 Product Property
+Schema.
 
 ```
 message Product {
-    enum ProductType {
-        UNSET_TYPE = 0;
-        GS1 = 1;
-    }
-    ProductType product_type = 1;
-    string identifier = 2;
-    string owner = 3;
-    repeated PropertyValue properties = 4;
+enum ProductType {
+UNSET_TYPE = 0;
+GS1 = 1;
+}
+ProductType product_type = 1;
+string identifier = 2;
+string owner = 3;
+repeated PropertyValue properties = 4;
 }
 ```
 
 The GS1 GTIN is an identifier used to identify trade items. 
-A GTIN is the data transmitted from a barcode scan and is made up of a company prefix (or GS1-8 prefix) and item reference. 
-We will initially support GTIN-12, GTIN-13, and GTIN-14. (GTIN-8 may be supported in the future.) 
-The GS1 GTIN specification is documented in section 3.3.2, Identification of a trade item (GTIN): AI (01), on page 140 of the **GS1 General Specification**: 
+A GTIN is the data transmitted from a barcode scan and is made up of a company
+prefix (or GS1-8 prefix) and item reference. 
+We will initially support GTIN-12, GTIN-13, and GTIN-14. (GTIN-8 may be
+supported in the future.) 
+The GS1 GTIN specification is documented in section 3.3.2, Identification of a
+trade item (GTIN): AI (01), on page 140 of the **GS1 General Specification**: 
+
 https://www.gs1.org/sites/default/files/docs/barcodes/GS1_General_Specifications.pdf
 
-The GS1-8 prefix is a unique string of 3 digits, and the GS1 company prefix consists of 4-12 digits. 
-The GS1-8 prefixes is issued by the GS1 Global Office. The GS1-8 prefix is allocated to a GS1 member organization to issue the GTIN-8’s to other areas. 
-The GS1 company prefix can be issued by the GS1 Global Office or a member organization. Usually issued to a company itself.
+The GS1-8 prefix is a unique string of 3 digits, and the GS1 company prefix
+consists of 4-12 digits. 
+The GS1-8 prefixes is issued by the GS1 Global Office. The GS1-8 prefix is
+allocated to a GS1 member organization to issue the GTIN-8’s to other areas. 
+The GS1 company prefix can be issued by the GS1 Global Office or a member
+organization. Usually issued to a company itself.
 
-Also relevant is the GS1-8 Prefix or GS1 Company Prefix which namespaces the GTIN by issuing organization. 
-GS1 manages the master data for company prefixes. Owning companies issue their own GTINs within their prefixed namespace. 
-Details about GS1 Company Prefixes can be found in section 1.4.4, GS1 Company Prefix, on page 20 of the GS1 General Specifications.
+Also relevant is the GS1-8 Prefix or GS1 Company Prefix which namespaces the
+GTIN by issuing organization. 
+GS1 manages the master data for company prefixes. Owning companies issue their
+own GTINs within their prefixed namespace. 
+Details about GS1 Company Prefixes can be found in section 1.4.4, GS1 Company
+Prefix, on page 20 of the GS1 General Specifications.
 
 ### Referencing Products
 Products are uniquely referenced by their product type and identifier. 
 For GS1, Products are referenced by the GTIN identifier. For example:
 ```
-    get_gs1_product(GTIN)
-    set_gs1_product(GTIN, GS1Product)
+get_gs1_product(GTIN)
+set_gs1_product(GTIN, GS1Product)
 ```
 
 ### Product Addressing in the Merkle-Radix State System
-In order to uniquely locate GS1 products in the Merkle-Radix state system, an address must be constructed which identifies the storage location of the Product representation.
+In order to uniquely locate GS1 products in the Merkle-Radix state system, an
+address must be constructed which identifies the storage location of the
+Product representation.
 
-All Grid addresses are prefixed by the 6-hex-character namespace prefix “621dee”,  
-Products are further prefixed under the Grid namespace with reserved enumerations of “02” (“00” and “01” being reserved for other purposes) indicating “Products” and an additional “01” indicating “GS1 Products”. 
+All Grid addresses are prefixed by the 6-hex-character namespace prefix
+“621dee”,  
+Products are further prefixed under the Grid namespace with reserved
+enumerations of “02” (“00” and “01” being reserved for other purposes)
+indicating “Products” and an additional “01” indicating “GS1 Products”. 
 
 Therefore, all addresses starting with:
 ```
-    “621dee” + “02” + “01”
+“621dee” + “02” + “01”
 ```
-are Grid GS1 Products identified by a GTIN and are expected to contain a Product representation which conforms with the GS1 product schema.
+are Grid GS1 Products identified by a GTIN and are expected to contain a
+Product representation which conforms with the GS1 product schema.
 
-GTIN formats consist of 14-digit “numeric strings” which include some amount of internal “0” padding depending on the specific GTIN format (GTIN-8, GTIN-12, GTIN-13, or GTIN-14). 
-After the 10-hex-characters that are consumed by the grid namespace prefix, the product, and GS1 prefixes, there are 60 hex characters remaining in the address. 
-The 14 digits of the GTIN can be left padded with 44-hex-character zeroes and right padded with 2-hex-character zeroes to accommodate potential future storage associated with the GS1 Product representation, 
+GTIN formats consist of 14-digit “numeric strings” which include some amount of
+internal “0” padding depending on the specific GTIN format (GTIN-8, GTIN-12,
+GTIN-13, or GTIN-14). 
+After the 10-hex-characters that are consumed by the grid namespace prefix, the
+product, and GS1 prefixes, there are 60 hex characters remaining in the
+address. 
+The 14 digits of the GTIN can be left padded with 44-hex-character zeroes and
+right padded with 2-hex-character zeroes to accommodate potential future
+storage associated with the GS1 Product representation, 
 for example:
 
 ```
-   “621dee” + “02” + “01” + “00000000000000000000000000000000000000000000” + 14-character “numeric string” GTIN + “00”
+“621dee” + “02” + “01” + “00000000000000000000000000000000000000000000” +
+14-character “numeric string” GTIN + “00”
 ```
 
-A full GS1 Product address using the example GTIN from https://www.gtin.info/ would therefore be:
+A full GS1 Product address using the example GTIN from https://www.gtin.info/
+would therefore be:
 ```
-    “621dee0201000000000000000000000000000000000000000000000001234560001200”
+“621dee0201000000000000000000000000000000000000000000000001234560001200”
 ```
 
 ## Transaction Payload and Execution
@@ -139,52 +197,61 @@ defined in the ProductPayload.
 
 ```
 message ProductPayload {
-    enum Actions {
-        UNSET_ACTION = 0;
-        PRODUCT_CREATE = 1;
-        PRODUCT_UPDATE = 2;
-        PRODUCT_DELETE = 3;
-    }
+enum Actions {
+UNSET_ACTION = 0;
+PRODUCT_CREATE = 1;
+PRODUCT_UPDATE = 2;
+PRODUCT_DELETE = 3;
+}
 
-    Action action = 1;
+Action action = 1;
 
-    ProductCreateAction product_create = 2;
-    ProductUpdateAction product_update = 3;
-    ProductDeleteAction product_delete = 4;
+ProductCreateAction product_create = 2;
+ProductUpdateAction product_update = 3;
+ProductDeleteAction product_delete = 4;
 }
 ```
 
 ### ProductCreateAction
 
-ProductCreateAction adds a new product to state. The transaction should be submitted by an agent, 
-which is identified by its signing key, acting on behalf of the organization that corresponds to the owner in the create 
-transaction. (Organizations and agents are defined by the Pike smart contract.)
+ProductCreateAction adds a new product to state. The transaction should be
+submitted by an agent, 
+which is identified by its signing key, acting on behalf of the organization
+that corresponds to the owner in the create 
+transaction. (Organizations and agents are defined by the Pike smart
+contract.)
 
 ```
 message ProductCreateAction {
-    enum ProductType {
-        UNSET_TYPE = 0;
-        GS1 = 1;
-    }
-    // product_type and identifier are used in deriving the state address
-    ProductType product_type = 1;
-    string identifier = 2;
-    string owner = 3;
-    repeated PropertyValues properties = 4;
+enum ProductType {
+UNSET_TYPE = 0;
+GS1 = 1;
+}
+// product_type and identifier are used in deriving the state address
+ProductType product_type = 1;
+string identifier = 2;
+string owner = 3;
+repeated PropertyValues properties = 4;
 }
 ```
 
 If a product with identifier already exists the transaction is invalid.
 
-The signer of the transaction must be an agent in the Pike state and must belong to an organization in Pike state, 
-otherwise the transaction is invalid.  The agent must have the permission can_create_product for the organization, 
+The signer of the transaction must be an agent in the Pike state and must
+belong to an organization in Pike state, 
+otherwise the transaction is invalid.  The agent must have the permission
+can_create_product for the organization, 
 otherwise the transaction is invalid.
 
-If the product type is GS1, the organization must contain a GS1 Company Prefix in its metadata (gs1_company_prefixes), 
-and the prefix must match the company prefix in the identifier, which is a gtin if GS1, otherwise the transaction is invalid.
+If the product type is GS1, the organization must contain a GS1 Company Prefix
+in its metadata (gs1_company_prefixes), 
+and the prefix must match the company prefix in the identifier, which is a gtin
+if GS1, otherwise the transaction is invalid.
 
-The properties must be valid for the product type. For example, if the product is GS1 product, its properties must only 
-contain properties that are included in the GS1 Schema. If it includes a property not in the GS1 Scheme the transaction is invalid. 
+The properties must be valid for the product type. For example, if the product
+is GS1 product, its properties must only 
+contain properties that are included in the GS1 Schema. If it includes a
+property not in the GS1 Scheme the transaction is invalid. 
 
 The product will be set in state.
 
@@ -199,32 +266,42 @@ The outputs for ProductCreateAction must include:
 
 ### ProductUpdateAction
 
-ProductUpdateAction updates an existing product in state. The transaction should be submitted by an agent, identified by its signing key, acting on behalf of an organization that corresponds to the owner in the product being updated. (Organizations and agents are defined by the Pike smart contract.)
+ProductUpdateAction updates an existing product in state. The transaction
+should be submitted by an agent, identified by its signing key, acting on
+behalf of an organization that corresponds to the owner in the product being
+updated. (Organizations and agents are defined by the Pike smart contract.)
 ```
 message ProductUpdateAction {
-    enum ProductType {
-        UNSET_TYPE = 0;
-        GS1 = 1;
-    }
-    // product_type and identifier are used in deriving the state address
-    ProductType product_type = 1;
-    string identifier = 2;
-    // this will replace all properties currently defined
-    repeated PropertyValues properties = 3;
+enum ProductType {
+UNSET_TYPE = 0;
+GS1 = 1;
+}
+// product_type and identifier are used in deriving the state address
+ProductType product_type = 1;
+string identifier = 2;
+// this will replace all properties currently defined
+repeated PropertyValues properties = 3;
 }
 ```
 
 If a product with identifier does not exist the transaction is invalid.
 
-The signer of the transaction must be an agent in the Pike state and must belong to an organization in Pike state, otherwise the transaction is invalid.
+The signer of the transaction must be an agent in the Pike state and must
+belong to an organization in Pike state, otherwise the transaction is invalid.
 
-The owner in the product must match the organization that the agent belongs to, otherwise the transaction is invalid.
+The owner in the product must match the organization that the agent belongs to,
+otherwise the transaction is invalid.
 
-The agent must have the permission can_update_prouduct for the organization, otherwise the transaction is invalid.
+The agent must have the permission can_update_prouduct for the organization,
+otherwise the transaction is invalid.
 
-The new properties must be valid for the product type. For example, if the product is GS1 product, its properties must only contain properties that are included in the GS1 Schema. If it includes a property not in the GS1 Scheme the transaction is invalid. 
+The new properties must be valid for the product type. For example, if the
+product is GS1 product, its properties must only contain properties that are
+included in the GS1 Schema. If it includes a property not in the GS1 Scheme the
+transaction is invalid. 
 
-The properties in the product will be swapped for the new properties and the updated product will be set in state.
+The properties in the product will be swapped for the new properties and the
+updated product will be set in state.
 
 The inputs for ProductUpdateAction must include:
 * Address of the Agent submitting the transaction
@@ -236,27 +313,37 @@ The outputs for ProductUpdateAction must include:
 * Address of the Product updated
 
 ### ProductDeleteAction
-ProductDeleteAction removes an existing product from state. The transaction should be submitted by an agent, identified by its signing key, acting on behalf of the organization that corresponds to the org_id in the product being updated. (Organizations and agents are defined by the Pike smart contract.)
+ProductDeleteAction removes an existing product from state. The transaction
+should be submitted by an agent, identified by its signing key, acting on
+behalf of the organization that corresponds to the org_id in the product being
+updated. (Organizations and agents are defined by the Pike smart contract.)
 ```
 message ProductDeleteAction {
-    enum ProductType {
-        UNSET_TYPE = 0;
-        GS1 = 1;
-    }
-    // product_type and identifier are used in deriving the state address
-    ProductType product_type = 1;	
-    string identifier = 2;
- }
+enum ProductType {
+UNSET_TYPE = 0;
+GS1 = 1;
+}
+// product_type and identifier are used in deriving the state address
+ProductType product_type = 1;    
+string identifier = 2;
+}
 ```
-If the grid setting grid.product.allow_delete is set to false, this transaction is invalid. The default value for grid.product.allow_delete is true.This setting is stored using the Sawtooth Settings smart contract, more information can be found here https://sawtooth.hyperledger.org/docs/core/releases/latest/transaction_family_specifications/settings_transaction_family.html
+If the grid setting grid.product.allow_delete is set to false, this transaction
+is invalid. The default value for grid.product.allow_delete is true.This
+setting is stored using the Sawtooth Settings smart contract, more information
+can be found here
+https://sawtooth.hyperledger.org/docs/core/releases/latest/transaction_family_specifications/settings_transaction_family.html
 
 If a product with identifier does not exist the transaction is invalid.
 
-The signer of the transaction must be an agent in the Pike state and must belong to an organization in Pike state, otherwise the transaction is invalid.
+The signer of the transaction must be an agent in the Pike state and must
+belong to an organization in Pike state, otherwise the transaction is invalid.
 
-The owner in the product must match the organization that the agent belongs to, otherwise the transaction is invalid.
+The owner in the product must match the organization that the agent belongs to,
+otherwise the transaction is invalid.
 
-The agent must have the permission “can_delete_product” for the organization, otherwise the transaction is invalid.
+The agent must have the permission “can_delete_product” for the organization,
+otherwise the transaction is invalid.
 
 The inputs for ProductDeleteAction must include:
 * Address of the Agent submitting the transaction
@@ -267,13 +354,14 @@ The outputs for ProductUpdateAction must include:
 * Address of the Product to be deleted
 
 ### Defined GS1 Properties
-An initial set of GS1 properties will be predefined within Grid. Each property will have a property definition of the following format:
+An initial set of GS1 properties will be predefined within Grid. Each property
+will have a property definition of the following format:
 ```
 PropertyDefinition(
-    name="<GSI Application Identifier>",
-    data_type=PropertyDefinition.DataType.STRING,
-    required=False,
-    description="A description of the GS1 data."
+name="<GSI Application Identifier>",
+data_type=PropertyDefinition.DataType.STRING,
+required=False,
+description="A description of the GS1 data."
 )
 ```
 
@@ -303,43 +391,68 @@ The list of predefined properties from the GS1 Spec:
 # Drawbacks
 [drawbacks]: #drawbacks
 
-Each GTIN format, except GTIN-8, contains an GS1 Company Prefix organizational identifier encoded into it, and this RFC duplicates the organization identification with a Grid-specific owner field to tie the product to organizations managed in Pike. In the future, it may be good to use the GTIN’s organizational identifier directly.
+Each GTIN format, except GTIN-8, contains an GS1 Company Prefix organizational
+identifier encoded into it, and this RFC duplicates the organization
+identification with a Grid-specific owner field to tie the product to
+organizations managed in Pike. In the future, it may be good to use the GTIN’s
+organizational identifier directly.
 
-Currently, Pike does not provide a place to store a GS1 Company Prefix, and the permissions around who is authorized to provide this prefix is complicated and not a direct extension of how Pike currently works. As such it is out of the scope of this RFC. 
+Currently, Pike does not provide a place to store a GS1 Company Prefix, and the
+permissions around who is authorized to provide this prefix is complicated and
+not a direct extension of how Pike currently works. As such it is out of the
+scope of this RFC. 
 
-Instead, Pike’s organization definition will be extended to include metadata, similar to Agent’s metadata. Metadata is a Key,Value store of arbitrary data.  The GS1 Company Prefix will be stored in the metadata under “gs1_company_prefix”. 
+Instead, Pike’s organization definition will be extended to include metadata,
+similar to Agent’s metadata. Metadata is a Key,Value store of arbitrary data.
+The GS1 Company Prefix will be stored in the metadata under
+“gs1_company_prefix”. 
 
-Solving how to properly provide GS1 Company Prefixes to a Pike Organization will be solved in a future RFC.
+Solving how to properly provide GS1 Company Prefixes to a Pike Organization
+will be solved in a future RFC.
 
-Trade items can include non-material goods, such as services, which will also need to be represented within Grid. This is not covered by this RFC.
+Trade items can include non-material goods, such as services, which will also
+need to be represented within Grid. This is not covered by this RFC.
 
-To expand the product schema to support all GS1 app id’s as well as keeping it all organized, there will need to be some refactoring done at the grid primitive level to support lists in the schema. 
+To expand the product schema to support all GS1 app id’s as well as keeping it
+all organized, there will need to be some refactoring done at the grid
+primitive level to support lists in the schema. 
 
-Currently, we will **__exclude clothing, and furniture__** from the product properties. Keeping the focus on food items for the initial implementation of product.
+Currently, we will **__exclude clothing, and furniture__** from the product
+properties. Keeping the focus on food items for the initial implementation of
+product.
 
 
 # Rationale and alternatives
 [alternatives]: #alternatives
 
-Starting with just capturing food items allows us to figure out the complexities associated with products in general. By starting with the GS1 standards/app identifiers for produce (food) products, we will be able to iterate and get it right for one product space before moving on to others. i.e. clothing, furniture, etc.
+Starting with just capturing food items allows us to figure out the
+complexities associated with products in general. By starting with the GS1
+standards/app identifiers for produce (food) products, we will be able to
+iterate and get it right for one product space before moving on to others. i.e.
+clothing, furniture, etc.
 
 Some details on products that can be used for a future iteration: 
-[GS1 Apparel and General Merchandise](https://www.gs1us.org/DesktopModules/Bring2mind/DMX/Download.aspx?Command=Core_Download&EntryId=1067&language=en-US&PortalId=0&TabId=134)
+[GS1 Apparel and General
+Merchandise](https://www.gs1us.org/DesktopModules/Bring2mind/DMX/Download.aspx?Command=Core_Download&EntryId=1067&language=en-US&PortalId=0&TabId=134)
 
 ### Clothing:
 Material content:  
-This element is used to indicate the material composition. This element is used in conjunction with the percentage.
+This element is used to indicate the material composition. This element is used
+in conjunction with the percentage.
 
 Material Percentage:  
-Net weight percentage of a product material of the first main material. The percentages must add up to 100.
+Net weight percentage of a product material of the first main material. The
+percentages must add up to 100.
 
 Material Percentage:  
-Net weight percentage of a product material of the first main material. The percentages must add up to 100.
+Net weight percentage of a product material of the first main material. The
+percentages must add up to 100.
 
 ### Furniture:
 
 Number of pieces:     
-The total number of separately packaged components comprising a single trade item.
+The total number of separately packaged components comprising a single trade
+item.
 
 Look at section 3.5.7 Packaging component number AI (243)
 
@@ -347,12 +460,15 @@ Look at section 3.5.7 Packaging component number AI (243)
 # Prior Art
 [prior-art]: #prior-art
 
-[Pike Transaction Family Specification](https://github.com/hyperledger/sawtooth-sabre/blob/master/contracts/sawtooth-pike/docs/source/pike_transaction_family.rst)
+[Pike Transaction Family
+Specification](https://github.com/hyperledger/sawtooth-sabre/blob/master/contracts/sawtooth-pike/docs/source/pike_transaction_family.rst)
 
 The Sawtooth Supply Chain mechanism to define field types.
-[Sawtooth Supply Chain Expanded Data Types](https://github.com/hyperledger/sawtooth-rfcs/blob/master/text/0013-supply-chain-expand-data-types.md)
+[Sawtooth Supply Chain Expanded Data
+Types](https://github.com/hyperledger/sawtooth-rfcs/blob/master/text/0013-supply-chain-expand-data-types.md)
 
 
 
 # Unresolved questions
 [unresolved]: #unresolved-questions
+

--- a/0000-product.md
+++ b/0000-product.md
@@ -124,10 +124,19 @@ Schema Transaction Family and are restricted to the fields and rules of the GS1
 Product schema.  Transactions which are responsible for setting product state
 values must ensure that the properties conform with the requirements of the GS1
 Product Property Schema.
-
-``` message Product { enum ProductNamespace { UNSET_NAMESPACE = 0; GS1 = 1; }
-string product_id = 1; ProductNamespace product_namespace = 2; string owner = 3;
-repeated PropertyValue properties = 4; } ```
+sadfds
+``` 
+message Product { 
+    enum ProductNamespace { 
+        UNSET_NAMESPACE = 0; 
+        GS1 = 1; 
+    }
+    string product_id = 1; 
+    ProductNamespace product_namespace = 2; 
+    string owner = 3;
+    repeated PropertyValue properties = 4; 
+} 
+```
 
 The GS1 GTIN is an identifier (product_id) used to identify trade items.  A GTIN
 is the data transmitted from a barcode scan and is made up of a company prefix
@@ -155,8 +164,10 @@ page 20 of the GS1 General Specifications.
 Products are uniquely referenced by their product_id and product_namespace.  For
 GS1, Products are referenced by the GTIN identifier. For example:
 
-``` get_product(product_id) // GTIN set_product(product_id, product) // GTIN,
-gs1Product ```
+``` 
+get_product(product_id) // GTIN 
+set_product(product_id, product) // GTIN, gs1Product 
+```
 
 ### Product Addressing in the Merkle-Radix State System
 
@@ -171,7 +182,9 @@ indicating “Products” and an additional “01” indicating “GS1 Products�
 
 Therefore, all addresses starting with:
 
-``` “621dee” + “02” + “01” ```
+``` 
+“621dee” + “02” + “01” 
+```
 
 are Grid GS1 Products identified by a GTIN and are expected to contain a Product
 representation which conforms with the GS1 product schema.
@@ -185,13 +198,17 @@ remaining in the address.  The 14 digits of the GTIN can be left padded with
 accommodate potential future storage associated with the GS1 Product
 representation, for example:
 
-``` “621dee” + “02” + “01” +“00000000000000000000000000000000000000000000” +
-14-character “numeric string” product_id + “00” // product_id == GTIN ```
+``` 
+“621dee” + “02” + “01” +“00000000000000000000000000000000000000000000” +
+14-character “numeric string” product_id + “00” // product_id == GTIN 
+```
 
 A full GS1 Product address using the example GTIN from https://www.gtin.info/
 would therefore be:
 
-``` “621dee0201000000000000000000000000000000000000000000000001234560001200” ```
+``` 
+“621dee0201000000000000000000000000000000000000000000000001234560001200” 
+```
 
 ## Transaction Payload and Execution
 
@@ -203,13 +220,22 @@ allows for the action payload to be dispatched to the appropriate logic.
 Only the defined actions are available and only one action payload should be
 defined in the ProductPayload.
 
-``` message ProductPayload { enum Actions { UNSET_ACTION = 0; PRODUCT_CREATE =
-1; PRODUCT_UPDATE = 2; PRODUCT_DELETE = 3; }
+``` 
+message ProductPayload { 
+    enum Actions { 
+        UNSET_ACTION = 0; 
+        PRODUCT_CREATE = 1; 
+        PRODUCT_UPDATE = 2; 
+        PRODUCT_DELETE = 3; 
+    }
 
     Action action = 1;
 
-    ProductCreateAction product_create = 2; ProductUpdateAction product_update =
-3; ProductDeleteAction product_delete = 4; } ```
+    ProductCreateAction product_create = 2; 
+    ProductUpdateAction product_update = 3; 
+    ProductDeleteAction product_delete = 4; 
+} 
+```
 
 ### ProductCreateAction
 
@@ -218,27 +244,29 @@ submitted by an agent, which is identified by its signing key, acting on behalf
 of the organization that corresponds to the owner in the create transaction.
 (Organizations and agents are defined by the Pike smart contract.)
 
-``` message ProductCreateAction { enum Product_Namespace { UNSET_NAMESPACE = 0;
-GS1 = 1; }
+``` 
+message ProductCreateAction { 
+    enum Product_Namespace { 
+        UNSET_NAMESPACE = 0;
+        GS1 = 1; 
+    }
     // product_namespace and product_id are used in deriving the state address
-    Product_Namespace product_namespace = 1; string product_id = 2; string owner
-= 3; repeated PropertyValues properties = 4; } ```
+    Product_Namespace product_namespace = 1; 
+    string product_id = 2; 
+    string owner = 3; 
+    repeated PropertyValues properties = 4; 
+} 
+```
 
 Validation requirements:
 
-* If a product with product_id already exists the transaction is invalid.  The
-* signer of the transaction must be an agent in the Pike state and must
+* If a product with product_id already exists the transaction is invalid.  
+* The signer of the transaction must be an agent in the Pike state and must
 belong to an organization in Pike state, otherwise the transaction is invalid.
-The agent must have the permission can_create_product for the organization,
+* The agent must have the permission can_create_product for the organization,
 otherwise the transaction is invalid.
-* If the product_namespace is GS1, the organization must contain a GS1 Company
-* Prefix in its metadata (gs1_company_prefixes), and the prefix must match the
-* company prefix in the product_id, which is a gtin if GS1, otherwise the
-* transaction is invalid.  The properties must be valid for the
-* product_namespace. For example, if the productis GS1 product, its properties
-* must only contain properties that are includedin the GS1 Schema. If it
-* includes a property not in the GS1 Schema the
-transaction is invalid.  _The base GS1 schema will be defined in a future RFC._
+* If the product_namespace is GS1, the organization must contain a GS1 Company Prefix in its metadata (gs1_company_prefixes), and the prefix must match the company prefix in the product_id, which is a gtin if GS1, otherwise the transaction is invalid.  
+* The properties must be valid for the product_namespace. For example, if the product is GS1 product, its properties must only contain properties that are includedin the GS1 Schema. If it includes a property not in the GS1 Schema the transaction is invalid.  _The base GS1 schema will be defined in a future RFC._
 
 The product will be set in state.
 
@@ -259,12 +287,19 @@ be submitted by an agent, identified by its signing key, acting on behalf of an
 organization that corresponds to the owner in the product being updated.
 (Organizations and agents are defined by the Pike smart contract.)
 
-``` message ProductUpdateAction { enum Product_Namespace { UNSET_NAMESPACE = 0;
-GS1 = 1; }
+``` 
+message ProductUpdateAction { 
+    enum Product_Namespace { 
+            UNSET_NAMESPACE = 0;
+            GS1 = 1; 
+    }
     // product_namespace and product_id are used in deriving the state address
-    Product_Namespace product_namespace = 1; string product_id = 2;
+    Product_Namespace product_namespace = 1; 
+    string product_id = 2;
     // this will replace all properties currently defined
-    repeated PropertyValues properties = 4; } ```
+    repeated PropertyValues properties = 4; 
+} 
+```
 
 Validation requirements:
 
@@ -272,14 +307,11 @@ Validation requirements:
 * signer of the transaction must be an agent in the Pike state and must
 belong to an organization in Pike state, otherwise the transaction is invalid.
 * The owner in the product must match the organization that the agent belongs
-* to, otherwise the transaction is invalid.  The agent must have the permission
-* can_update_prouduct for the organization,
+* to, otherwise the transaction is invalid.  
+* The agent must have the permission can_update_prouduct for the organization,
 otherwise the transaction is invalid.
-* The new properties must be valid for the product_namespace. For example, if
-* theproduct is GS1 product, its properties must only contain properties that
-* are
-included in the GS1 Schema. If it includes a property not in the GS1 Scheme the
-transaction is invalid.
+* The new properties must be valid for the product_namespace. 
+* For example, if the product is GS1 product, its properties must only contain properties that are included in the GS1 Schema. If it includes a property not in the GS1 Scheme the transaction is invalid.
 
 The properties in the product will be swapped for the new properties and the
 updated product will be set in state.
@@ -301,10 +333,17 @@ should be submitted by an agent, identified by its signing key, acting on behalf
 of the organization that corresponds to the org_id in the product being updated.
 (Organizations and agents are defined by the Pike smart contract.)
 
-``` message ProductDeleteAction { enum Product_Namespace { UNSET_NAMESPACE = 0;
-GS1 = 1; }
+``` 
+message ProductDeleteAction { 
+    enum Product_Namespace { 
+        UNSET_NAMESPACE = 0;
+        GS1 = 1; 
+    }
     // product_namespace and product_id are used in deriving the state address
-    Product_Namespace product_namespace = 1; string product_id = 2; } ```
+    Product_Namespace product_namespace = 1; 
+    string product_id = 2; 
+} 
+```
 
 If the grid setting grid.product.allow_delete is set to false, this transaction
 is invalid. The default value for grid.product.allow_delete is true. This
@@ -317,9 +356,8 @@ Validation requirements:
 * If a product with product_id does not exist the transaction is invalid.  The
 * signer of the transaction must be an agent in the Pike state and must
 belong to an organization in Pike state, otherwise the transaction is invalid.
-* The owner in the product must match the organization that the agent belongs
-* to, otherwise the transaction is invalid.  The agent must have the permission
-* “can_delete_product” for the organization,
+* The owner in the product must match the organization that the agent belongs to, otherwise the transaction is invalid.  
+* The agent must have the permission “can_delete_product” for the organization,
 otherwise the transaction is invalid.
 
 The inputs for ProductDeleteAction must include:
@@ -336,9 +374,13 @@ The outputs for ProductUpdateAction must include:
 An initial set of GS1 properties will be predefined within Grid. Each property
 will have a property definition of the following format:
 
-``` PropertyDefinition( name="<GS1 Property>",
-data_type=PropertyDefinition.DataType.STRING, required=False, description="A
-description of the GS1 data.") ```
+``` 
+PropertyDefinition( 
+    name="<GS1 Property>",
+    data_type=PropertyDefinition.DataType.STRING, 
+    required=False, 
+    description="A description of the GS1 data.") 
+```
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/0000-product.md
+++ b/0000-product.md
@@ -81,7 +81,10 @@ are supported:
   state.
 * ProductDelete - remove a Product from state.
 
-*Disclaimer: ProductDelete does not remove the record of existance of a product. The history and record of existance of that product will remain. This is simply a mechanism to free up memory in state when it is known that a product will no longer be in existance.*
+*Disclaimer: ProductDelete does not remove the record of existance of a product.
+The history and record of existance of that product will remain. This is simply
+a mechanism to free up memory in state when it is known that a product will no
+longer be in existance.*
 
 ## Permissions
 
@@ -133,15 +136,21 @@ message Product {
         UNSET_NAMESPACE = 0; 
         GS1 = 1; 
     }
-    string product_id = 1; 
-    ProductNamespace product_namespace = 2; 
+    
+    ProductNamespace product_namespace = 1; 
+    string product_id = 2; 
     string owner = 3;
     repeated PropertyValue properties = 4; 
 } 
 ```
 
 The GS1 GTIN is an identifier (product_id) used to identify trade items.  A GTIN
-is the data transmitted from a data carrier (barcode, rfid, etc) scan and is made up of a company prefix (or GS1-8 prefix) and item reference.  We will initially support GTIN-12, GTIN-13, and GTIN-14. (GTIN-8 may be supported in the future.) The GS1 GTIN specification is documented in section 3.3.2, Identification of a trade item (GTIN): AI (01), on page 140 of the **GS1 General Specification**:
+is the data transmitted from a data carrier (barcode, rfid, etc) scan and is
+made up of a company prefix (or GS1-8 prefix) and item reference.  We will
+initially support GTIN-12, GTIN-13, and GTIN-14. (GTIN-8 may be supported in the
+future.) The GS1 GTIN specification is documented in section 3.3.2,
+Identification of a trade item (GTIN): AI (01), on page 140 of the **GS1 General
+Specification**:
 
 https://www.gs1.org/sites/default/files/docs/barcodes/GS1_General_Specifications.pdf
 
@@ -181,8 +190,8 @@ indicating “Products” and an additional “01” indicating “GS1 Products�
 Therefore, all addresses starting with:
 
 ``` 
-“621dee” + “02” + “01” 
-```
+“621dee” + “02” + “01”
+ ```
 
 are Grid GS1 Products identified by a GTIN and are expected to contain a Product
 representation which conforms with the GS1 product schema.
@@ -229,8 +238,7 @@ message ProductPayload {
 
     Action action = 1;
 
-    // Approximately when transaction was submitted, as a Unix UTC
-    // timestamp
+    // Approximately when transaction was submitted, as a Unix UTC timestamp
     uint64 timestamp = 2;
 
     ProductCreateAction product_create = 3; 
@@ -267,16 +275,20 @@ Validation requirements:
 belong to an organization in Pike state, otherwise the transaction is invalid.
 * The agent must have the permission can_create_product for the organization,
 otherwise the transaction is invalid.
-* If the product_namespace is GS1, the organization must contain a GS1 Company Prefix in its metadata (gs1_company_prefixes), and the prefix must match the company prefix in the product_id, which is a gtin if GS1, otherwise the transaction is invalid.  
-* The properties must be valid for the product_namespace. For example, if the product is GS1 product, its properties must only contain properties that are includedin the GS1 Schema. If it includes a property not in the GS1 Schema the transaction is invalid.  _The base GS1 schema will be defined in a future RFC._
+* If the product_namespace is GS1, the organization must contain a GS1 Company Prefix in its metadata (gs1_company_prefixes), and the prefix must match the company prefix in the product_id, which is a gtin if GS1, otherwise the
+transaction is invalid.  
+* The properties must be valid for the product_namespace. For example, if the product is GS1 product, its properties must only contain properties that are includedin the GS1 Schema. If it includes a property not in the GS1 Schema the transaction is invalid.  
 
-The product will be set in state.
+_The base GS1 schema will be defined in a future RFC._
+
+If all requirements are met, the transaction will be accepted, the batch will be written to a block, and the product will be created in state.
 
 The inputs for ProductCreateAction must include:
 
-* Address of the Agent submitting the transaction Address of the Organization
-* the Product is being created for Address of the Product Namespace Schema the
-* product’s properties must match Address of the Product to be created
+* Address of the Agent submitting the transaction 
+* Address of the Organization the Product is being created for 
+* Address of the Product Namespace Schema the product’s properties must match 
+* Address of the Product to be created
 
 The outputs for ProductCreateAction must include:
 
@@ -289,11 +301,10 @@ be submitted by an agent, identified by its signing key, acting on behalf of an
 organization that corresponds to the owner in the product being updated.
 (Organizations and agents are defined by the Pike smart contract.)
 
-``` 
-message ProductUpdateAction { 
+``` message ProductUpdateAction { 
     enum Product_Namespace { 
-            UNSET_NAMESPACE = 0;
-            GS1 = 1; 
+        UNSET_NAMESPACE = 0;
+        GS1 = 1; 
     }
     // product_namespace and product_id are used in deriving the state address
     Product_Namespace product_namespace = 1; 
@@ -305,24 +316,25 @@ message ProductUpdateAction {
 
 Validation requirements:
 
-* If a product with product_id does not exist the transaction is invalid.  The
-* signer of the transaction must be an agent in the Pike state and must
+* If a product with product_id does not exist the transaction is invalid.  
+* The signer of the transaction must be an agent in the Pike state and must
 belong to an organization in Pike state, otherwise the transaction is invalid.
-* The owner in the product must match the organization that the agent belongs
-* to, otherwise the transaction is invalid.  
-* The agent must have the permission can_update_prouduct for the organization,
+* The owner in the product must match the organization that the agent belongs to, otherwise the transaction is invalid.  
+* The agent must have the permission can_update_product for the organization,
 otherwise the transaction is invalid.
-* The new properties must be valid for the product_namespace. 
-* For example, if the product is GS1 product, its properties must only contain properties that are included in the GS1 Schema. If it includes a property not in the GS1 Scheme the transaction is invalid.
+* The new properties must be valid for the product_namespace.  For example, if the product is GS1 product, its properties must only contain properties that are included in the GS1 Schema. If it includes a property not in the GS1 Scheme the transaction is invalid.
+  
+_The base GS1 schema will be defined in a future RFC._
 
 The properties in the product will be swapped for the new properties and the
 updated product will be set in state.
 
 The inputs for ProductUpdateAction must include:
 
-* Address of the Agent submitting the transaction Address of the Organization
-* the Product is being updated for Address of the Product Namespace Schema the
-* product’s properties must match Address of the Product to be updated
+* Address of the Agent submitting the transaction 
+* Address of the Organization the Product is being updated for 
+* Address of the Product Namespace Schema the product’s properties must match
+* Address of the Product to be updated
 
 The outputs for ProductUpdateAction must include:
 
@@ -335,7 +347,7 @@ should be submitted by an agent, identified by its signing key, acting on behalf
 of the organization that corresponds to the org_id in the product being updated.
 (Organizations and agents are defined by the Pike smart contract.)
 
-``` 
+```
 message ProductDeleteAction { 
     enum Product_Namespace { 
         UNSET_NAMESPACE = 0;
@@ -359,13 +371,12 @@ Validation requirements:
 * The signer of the transaction must be an agent in the Pike state and must
 belong to an organization in Pike state, otherwise the transaction is invalid.
 * The owner in the product must match the organization that the agent belongs to, otherwise the transaction is invalid.  
-* The agent must have the permission “can_delete_product” for the organization,
-otherwise the transaction is invalid.
+* The agent must have the permission “can_delete_product” for the organization otherwise the transaction is invalid.
 
 The inputs for ProductDeleteAction must include:
 
-* Address of the Agent submitting the transaction Address of the Organization
-* the Product is being deleted for Address of the Product to be deleted
+* Address of the Agent submitting the transaction 
+* Address of the Organization the Product is being deleted for Address of the Product to be deleted
 
 The outputs for ProductUpdateAction must include:
 
@@ -388,7 +399,11 @@ PropertyDefinition(
 [drawbacks]: #drawbacks
 
 
-Each GTIN is derived from three components. A GS1 Global Company Prefix (which also identifies the owner of the GTIN), and item reference number, and a check digit. This RFC duplicates the organization identification with a Grid-specific owner field to tie the product to organizations managed in Pike. In the future, it may be good to use the GTIN’s organizational identifier directly.
+Each GTIN is derived from three components. A GS1 Global Company Prefix (which
+also identifies the owner of the GTIN), and item reference number, and a check
+digit. This RFC duplicates the organization identification with a Grid-specific
+owner field to tie the product to organizations managed in Pike. In the future,
+it may be good to use the GTIN’s organizational identifier directly.
 
 Currently, Pike does not provide a place to store a GS1 Company Prefix, and the
 permissions around who is authorized to provide this prefix is complicated and
@@ -401,8 +416,9 @@ The GS1 Company Prefix will be stored in the metadata under
 “gs1_company_prefix”.
 
 Solving how to properly provide GS1 Company Prefixes to a Pike Organization will
-be solved in a future RFC. This future RFC should integrate the concepts of GLN and the smart contract associated with grid gs1 product should be updated to reflect that integration.
-`
+be solved in a future RFC. This future RFC should integrate the concepts of GLN
+and the smart contract associated with grid gs1 product should be updated to
+reflect that integration.  `
 
 Trade items can include non-material goods, such as services, which will also
 need to be represented within Grid. This is not covered by this RFC.
@@ -410,14 +426,20 @@ need to be represented within Grid. This is not covered by this RFC.
 Some examples of non-material goods: 
 
 - Batch/Lot (LGTIN) or Serialized (SGTIN) 
-- Logistical Cases/Pallets - Higher levels of packaging of the items - some of which are the trade unit between to parties although not necessarily the consumer unit. Identified sometimes with a GTIN but often times, due to their heterogeneous nature, with another GS1 identifier (SSCC).
-- Assets (returnable or fixed) - Identified with GRAI or GIAI - I presume like services (GSRN) OUT
+- Logistical Cases/Pallets - Higher levels of packaging of the items - some of
+  which are the trade unit between to parties although not necessarily the
+consumer unit. Identified sometimes with a GTIN but often times, due to their
+heterogeneous nature, with another GS1 identifier (SSCC).
+- Assets (returnable or fixed) - Identified with GRAI or GIAI - I presume like
+  services (GSRN) OUT
 
 To expand the product schema to support all GS1 properties as well as keeping it
 all organized, there will need to be some refactoring done at the grid primitive
 level to support lists in the schema.
 
-This implementation does not account for transfer-of-ownership scenarios, and should be implemented as a supplemental RFC at a later time. See: https://github.com/hyperledger/grid-rfcs/pull/5#discussion_r312211331
+This implementation does not account for transfer-of-ownership scenarios, and
+should be implemented as a supplemental RFC at a later time. See:
+https://github.com/hyperledger/grid-rfcs/pull/5#discussion_r312211331
 
 # Rationale and alternatives
 [alternatives]: #alternatives

--- a/0000-product.md
+++ b/0000-product.md
@@ -11,7 +11,7 @@ GS1 is a widely used data standard in enterprises and, given that positioning
 and familiarity, Grid support feels natural. 
 Additional implementations of Product for specialized industries or use cases
 may derive from or extend this implementation. _For the base implementation of a
-product on grid, there will be 2 fields. Gtin and a repeated key-value field._
+product on grid, there will be 3 fields. An identifier (gtin), a type (GS1), and a repeated key-value field._
 
 
 # Motivation
@@ -37,7 +37,7 @@ A **__product__** is an archetype of an item that is transacted, traded, or
 referenced in a supply chain. 
 Each product has a **__product type__**. This RFC defines a single product type
 for GS1; a product of the GS1 product type is called a GS1 product. 
-Note that this design supports adding additional product types in the future.
+Note that this design supports extending additional product types in the future.
 
 A product is referenced using a **__product identifier__**. 
 For GS1 products, the product identifier is a Global Trade Item Number (GTIN),

--- a/0000-product.md
+++ b/0000-product.md
@@ -90,7 +90,7 @@ organization that is associated with the GS1 company prefix encoded in the
 GTIN.  An organization must have the GS1 company prefix in the
 “gs1_company_prefixes” metadata field for its Pike organization.
 (Organization-level metadata will need to be implemented in Pike.) When
-a product is created, its owning organization is stored with the project in an
+a product is created, its owning organization is stored with the product in an
 “owner” field.
 
 Updates to products is restricted to agents acting on behalf of the

--- a/0000-product.md
+++ b/0000-product.md
@@ -101,7 +101,6 @@ Check digit validation:
 (https://www.gs1.org/services/how-calculate-check-digit-manually)
 
 
-
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
@@ -138,8 +137,7 @@ supported in the future.)
 The GS1 GTIN specification is documented in section 3.3.2, Identification of a
 trade item (GTIN): AI (01), on page 140 of the **GS1 General Specification**: 
 
-https://www.gs1.org/sites/default/files/docs/barcodes/GS1_General_Specifications
-.pdf
+https://www.gs1.org/sites/default/files/docs/barcodes/GS1_General_Specifications.pdf
 
 The GS1-8 prefix is a unique string of 3 digits, and the GS1 company prefix
 consists of 4-12 digits. 
@@ -356,8 +354,7 @@ If the grid setting grid.product.allow_delete is set to false, this transaction
 is invalid. The default value for grid.product.allow_delete is true.This
 setting is stored using the Sawtooth Settings smart contract, more information
 can be found here
-https://sawtooth.hyperledger.org/docs/core/releases/latest/transaction_family_sp
-ecifications/settings_transaction_family.html
+https://sawtooth.hyperledger.org/docs/core/releases/latest/transaction_family_specifications/settings_transaction_family.html
 
 If a product with identifier does not exist the transaction is invalid.
 
@@ -434,8 +431,7 @@ clothing, furniture, etc.
 
 Some details on products that can be used for a future iteration: 
 [GS1 Apparel and General
-Merchandise](https://www.gs1us.org/DesktopModules/Bring2mind/DMX/Download.aspx?C
-ommand=Core_Download&EntryId=1067&language=en-US&PortalId=0&TabId=134)
+Merchandise](https://www.gs1us.org/DesktopModules/Bring2mind/DMX/Download.aspx?Command=Core_Download&EntryId=1067&language=en-US&PortalId=0&TabId=134)
 
 ### Clothing:
 Material content:  
@@ -471,13 +467,11 @@ requirement.
 [prior-art]: #prior-art
 
 [Pike Transaction Family
-Specification](https://github.com/hyperledger/sawtooth-sabre/blob/master/contrac
-ts/sawtooth-pike/docs/source/pike_transaction_family.rst)
+Specification](https://github.com/hyperledger/sawtooth-sabre/blob/master/contracts/sawtooth-pike/docs/source/pike_transaction_family.rst)
 
 The Sawtooth Supply Chain mechanism to define field types.
 [Sawtooth Supply Chain Expanded Data
-Types](https://github.com/hyperledger/sawtooth-rfcs/blob/master/text/0013-supply
--chain-expand-data-types.md)
+Types](https://github.com/hyperledger/sawtooth-rfcs/blob/master/text/0013-supply-chain-expand-data-types.md)
 
 
 

--- a/0000-product.md
+++ b/0000-product.md
@@ -255,14 +255,14 @@ if GS1, otherwise the transaction is invalid.
 The properties must be valid for the product type. For example, if the product
 is GS1 product, its properties must only 
 contain properties that are included in the GS1 Schema. If it includes a
-property not in the GS1 Scheme the transaction is invalid. 
+property not in the GS1 Schema the transaction is invalid. 
 
 The product will be set in state.
 
 The inputs for ProductCreateAction must include:
 * Address of the Agent submitting the transaction
 * Address of the Organization the Product is being created for
-* Address of the Product Type Scheme the  product’s properties must match 
+* Address of the Product Type Schema the  product’s properties must match 
 * Address of the Product to be created
 
 The outputs for ProductCreateAction must include:
@@ -310,7 +310,7 @@ updated product will be set in state.
 The inputs for ProductUpdateAction must include:
 * Address of the Agent submitting the transaction
 * Address of the Organization the Product is being updated for
-* Address of the Product Type Scheme the product’s properties must match 
+* Address of the Product Type Schema the product’s properties must match 
 * Address of the Product to be updated
 
 The outputs for ProductUpdateAction must include:

--- a/0000-product.md
+++ b/0000-product.md
@@ -81,6 +81,8 @@ are supported:
   state.
 * ProductDelete - remove a Product from state.
 
+*Disclaimer: ProductDelete does not remove the record of existance of a product. The history and record of existance of that product will remain. This is simply a mechanism to free up memory in state when it is known that a product will no longer be in existance.*
+
 ## Permissions
 
 Creation of GS1 products is restricted to agents acting on behalf of the
@@ -139,11 +141,7 @@ message Product {
 ```
 
 The GS1 GTIN is an identifier (product_id) used to identify trade items.  A GTIN
-is the data transmitted from a barcode scan and is made up of a company prefix
-(or GS1-8 prefix) and item reference.  We will initially support GTIN-12,
-GTIN-13, and GTIN-14. (GTIN-8 may be supported in the future.) The GS1 GTIN
-specification is documented in section 3.3.2, Identification of a trade item
-(GTIN): AI (01), on page 140 of the **GS1 General Specification**:
+is the data transmitted from a data carrier (barcode, rfid, etc) scan and is made up of a company prefix (or GS1-8 prefix) and item reference.  We will initially support GTIN-12, GTIN-13, and GTIN-14. (GTIN-8 may be supported in the future.) The GS1 GTIN specification is documented in section 3.3.2, Identification of a trade item (GTIN): AI (01), on page 140 of the **GS1 General Specification**:
 
 https://www.gs1.org/sites/default/files/docs/barcodes/GS1_General_Specifications.pdf
 
@@ -390,11 +388,7 @@ PropertyDefinition(
 [drawbacks]: #drawbacks
 
 
-Each GTIN format, except GTIN-8, contains an GS1 Company Prefix organizational
-identifier encoded into it. and this RFC duplicates the organization
-identification with a Grid-specific owner field to tie the product to
-organizations managed in Pike. In the future, it may be good to use the GTIN’s
-organizational identifier directly.
+Each GTIN is derived from three components. A GS1 Global Company Prefix (which also identifies the owner of the GTIN), and item reference number, and a check digit. This RFC duplicates the organization identification with a Grid-specific owner field to tie the product to organizations managed in Pike. In the future, it may be good to use the GTIN’s organizational identifier directly.
 
 Currently, Pike does not provide a place to store a GS1 Company Prefix, and the
 permissions around who is authorized to provide this prefix is complicated and

--- a/0000-product.md
+++ b/0000-product.md
@@ -16,8 +16,7 @@ implementations of Product for specialized industries or use cases may derive
 from or extend this implementation.
 
 _For the base implementation of a product
-on grid, there will be 4 fields. A product_id, a product_type, an owner, and
-properties (a repeated key-value field)._
+on grid, there will be 4 fields. A product_id, a product_namespace, an owner, and properties (a repeated key-value field)._
 
 
 # Motivation
@@ -51,7 +50,7 @@ within Grid.
 
 A **__product__** is an archetype of an item that is transacted, traded, or
 referenced in a supply chain.  Each product has a **__product_type__**. This
-RFC defines a single product_type for GS1; a product of the GS1 product_type is
+RFC defines a single product_namespace for GS1; a product of the GS1 product_namespace is
 called a GS1 product.  Note that this design supports extending additional
 product types in the future.
 
@@ -95,7 +94,7 @@ a product is created, its owning organization is stored with the product in an
 
 Updates to products is restricted to agents acting on behalf of the
 organization stored in the product’s owner field.  Only property fields can be
-updated. Product_id, product_type, and owner fields are immutable.
+updated. Product_id, product_namespace, and owner fields are immutable.
 
 Deletion of products is restricted to agents acting on behalf of the
 organization in the product’s owner field.  A setting will turn off deletion
@@ -130,12 +129,12 @@ requirements of the GS1 Product Property Schema.
 
 ```
 message Product {
-    enum ProductType {
-        UNSET_TYPE = 0;
+    enum ProductNamespace {
+        UNSET_NAMESPACE = 0;
         GS1 = 1;
     }
     string product_id = 1;
-    ProductType product_type = 2;
+    ProductNamespace product_namespace = 2;
     string owner = 3;
     repeated PropertyValue properties = 4;
 }
@@ -165,7 +164,7 @@ GS1 Company Prefix, on page 20 of the GS1 General Specifications.
 
 ### Referencing Products
 
-Products are uniquely referenced by their product_id and product_type.  For
+Products are uniquely referenced by their product_id and product_namespace.  For
 GS1, Products are referenced by the GTIN identifier. For example:
 
 ```
@@ -250,12 +249,12 @@ of the organization that corresponds to the owner in the create transaction.
 
 ```
 message ProductCreateAction {
-    enum ProductType {
-        UNSET_TYPE = 0;
+    enum Product_Namespace {
+        UNSET_NAMESPACE = 0;
         GS1 = 1;
     }
-    // product_type and product_id are used in deriving the state address
-    ProductType product_type = 1;
+    // product_namespace and product_id are used in deriving the state address
+    Product_Namespace product_namespace = 1;
     string product_id = 2;
     string owner = 3;
     repeated PropertyValues properties = 4;
@@ -269,12 +268,12 @@ belong to an organization in Pike state, otherwise the transaction is invalid.
 The agent must have the permission can_create_product for the organization,
 otherwise the transaction is invalid.
 
-If the product_type is GS1, the organization must contain a GS1 Company Prefix
+If the product_namespace is GS1, the organization must contain a GS1 Company Prefix
 in its metadata (gs1_company_prefixes), and the prefix must match the company
 prefix in the product_id, which is a gtin if GS1, otherwise the transaction is
 invalid.
 
-The properties must be valid for the product_type. For example, if the product
+The properties must be valid for the product_namespace. For example, if the product
 is GS1 product, its properties must only contain properties that are included
 in the GS1 Schema. If it includes a property not in the GS1 Schema the
 transaction is invalid.  _The base GS1 schema will be defined in a future RFC._
@@ -301,12 +300,12 @@ updated. (Organizations and agents are defined by the Pike smart contract.)
 
 ```
 message ProductUpdateAction {
-    enum ProductType {
-        UNSET_TYPE = 0;
+    enum Product_Namespace {
+        UNSET_NAMESPACE = 0;
         GS1 = 1;
     }
-    // product_type and product_id are used in deriving the state address
-    ProductType product_type = 1;
+    // product_namespace and product_id are used in deriving the state address
+    Product_Namespace product_namespace = 1;
     string product_id = 2;
     // this will replace all properties currently defined
     repeated PropertyValues properties = 4;
@@ -324,7 +323,7 @@ otherwise the transaction is invalid.
 The agent must have the permission can_update_prouduct for the organization,
 otherwise the transaction is invalid.
 
-The new properties must be valid for the product_type. For example, if the
+The new properties must be valid for the product_namespace. For example, if the
 product is GS1 product, its properties must only contain properties that are
 included in the GS1 Schema. If it includes a property not in the GS1 Scheme the
 transaction is invalid.
@@ -352,12 +351,12 @@ updated. (Organizations and agents are defined by the Pike smart contract.)
 
 ```
 message ProductDeleteAction {
-    enum ProductType {
-        UNSET_TYPE = 0;
+    enum Product_Namespace {
+        UNSET_NAMESPACE = 0;
         GS1 = 1;
     }
-    // product_type and product_id are used in deriving the state address
-    ProductType product_type = 1;
+    // product_namespace and product_id are used in deriving the state address
+    Product_Namespace product_namespace = 1;
     string product_id = 2;
  }
 ```

--- a/0000-product.md
+++ b/0000-product.md
@@ -76,8 +76,8 @@ Products are managed by submitting transactions to Hyperledger Grid, which will
 process them with the Grid Product smart contract. The following transactions
 are supported:
 
-* ProductCreate - create a Product and store it in state.  ProductUpdate -
-* update (replace) the properties of a Product already in
+* ProductCreate - create a Product and store it in state.  
+* ProductUpdate - update (replace) the properties of a Product already in
   state.
 * ProductDelete - remove a Product from state.
 

--- a/0000-product.md
+++ b/0000-product.md
@@ -107,8 +107,8 @@ references to these products and deleting them could leave dangling references.
 
 ## GTIN Validation
 
-Creation of a resuable gtin validation function to programmatically express the
-equation used to validate a GTIN. It validates gtin format to avoid mistype
+Creation of a resuable GTIN validation function to programmatically express the
+equation used to validate a GTIN. It validates GTIN format to avoid mistype
 errors similar to a credit card validation. It's implemented as an extensible
 function such that further validation steps can be added, if needed. For details
 on the equation see: [Check digit
@@ -275,19 +275,15 @@ Validation requirements:
 belong to an organization in Pike state, otherwise the transaction is invalid.
 * The agent must have the permission can_create_product for the organization,
 otherwise the transaction is invalid.
-* If the product_namespace is GS1, the organization must contain a GS1 Company 
-Prefix in its metadata (gs1_company_prefixes), and the prefix must match the 
-company prefix in the product_id, which is a gtin if GS1, otherwise the
+* If the product_namespace is GS1, the organization must contain a GS1 Company
+
+Prefix in its metadata (gs1_company_prefixes), and the prefix must match the company prefix in the product_id, which is a GTIN if GS1, otherwise the
 transaction is invalid.  
-* The properties must be valid for the product_namespace. For example, if the 
-product is GS1 product, its properties must only contain properties that are 
-included in the GS1 Schema. If it includes a property not in the GS1 Schema 
-the transaction is invalid.  
+* The properties must be valid for the product_namespace. For example, if the product is GS1 product, its properties must only contain properties that are includedin the GS1 Schema. If it includes a property not in the GS1 Schema the transaction is invalid.  
 
 _The base GS1 schema will be defined in a future RFC._
 
-If all requirements are met, the transaction will be accepted, the batch will 
-be written to a block, and the product will be created in state.
+If all requirements are met, the transaction will be accepted, the batch will be written to a block, and the product will be created in state.
 
 The inputs for ProductCreateAction must include:
 
@@ -325,14 +321,10 @@ Validation requirements:
 * If a product with product_id does not exist the transaction is invalid.  
 * The signer of the transaction must be an agent in the Pike state and must
 belong to an organization in Pike state, otherwise the transaction is invalid.
-* The owner in the product must match the organization that the agent belongs 
-to, otherwise the transaction is invalid.  
+* The owner in the product must match the organization that the agent belongs to, otherwise the transaction is invalid.  
 * The agent must have the permission can_update_product for the organization,
 otherwise the transaction is invalid.
-* The new properties must be valid for the product_namespace.  For example, if 
-the product is GS1 product, its properties must only contain properties that 
-are included in the GS1 Schema. If it includes a property not in the GS1 
-Scheme the transaction is invalid.
+* The new properties must be valid for the product_namespace.  For example, if the product is GS1 product, its properties must only contain properties that are included in the GS1 Schema. If it includes a property not in the GS1 Scheme the transaction is invalid.
   
 _The base GS1 schema will be defined in a future RFC._
 
@@ -380,10 +372,8 @@ Validation requirements:
 * If a product with product_id does not exist the transaction is invalid.  
 * The signer of the transaction must be an agent in the Pike state and must
 belong to an organization in Pike state, otherwise the transaction is invalid.
-* The owner in the product must match the organization that the agent belongs 
-to, otherwise the transaction is invalid.  
-* The agent must have the permission “can_delete_product” for the organization 
-otherwise the transaction is invalid.
+* The owner in the product must match the organization that the agent belongs to, otherwise the transaction is invalid.  
+* The agent must have the permission “can_delete_product” for the organization otherwise the transaction is invalid.
 
 The inputs for ProductDeleteAction must include:
 
@@ -450,8 +440,7 @@ all organized, there will need to be some refactoring done at the grid primitive
 level to support lists in the schema.
 
 This implementation does not account for transfer-of-ownership scenarios, and
-should be implemented as a supplemental RFC at a later time. See:
-https://github.com/hyperledger/grid-rfcs/pull/5#discussion_r312211331
+should be implemented as a supplemental RFC at a later time. 
 
 # Rationale and alternatives
 [alternatives]: #alternatives
@@ -486,7 +475,7 @@ Look at section 3.5.7 Packaging component number AI (243)
 ### Possible payload modifications:
 
 The owner field is not a _HARD_ requirement in in the product_state.proto. The
-owner (organization) could later be derived from the gtin, as we learn more
+owner (organization) could later be derived from the GTIN, as we learn more
 about gtins and integrate some kind of lookup functionality. That functionality
 is not included in this RFC and could be implemented at a later time.
 

--- a/0000-product.md
+++ b/0000-product.md
@@ -275,13 +275,19 @@ Validation requirements:
 belong to an organization in Pike state, otherwise the transaction is invalid.
 * The agent must have the permission can_create_product for the organization,
 otherwise the transaction is invalid.
-* If the product_namespace is GS1, the organization must contain a GS1 Company Prefix in its metadata (gs1_company_prefixes), and the prefix must match the company prefix in the product_id, which is a gtin if GS1, otherwise the
+* If the product_namespace is GS1, the organization must contain a GS1 Company 
+Prefix in its metadata (gs1_company_prefixes), and the prefix must match the 
+company prefix in the product_id, which is a gtin if GS1, otherwise the
 transaction is invalid.  
-* The properties must be valid for the product_namespace. For example, if the product is GS1 product, its properties must only contain properties that are includedin the GS1 Schema. If it includes a property not in the GS1 Schema the transaction is invalid.  
+* The properties must be valid for the product_namespace. For example, if the 
+product is GS1 product, its properties must only contain properties that are 
+included in the GS1 Schema. If it includes a property not in the GS1 Schema 
+the transaction is invalid.  
 
 _The base GS1 schema will be defined in a future RFC._
 
-If all requirements are met, the transaction will be accepted, the batch will be written to a block, and the product will be created in state.
+If all requirements are met, the transaction will be accepted, the batch will 
+be written to a block, and the product will be created in state.
 
 The inputs for ProductCreateAction must include:
 
@@ -319,10 +325,14 @@ Validation requirements:
 * If a product with product_id does not exist the transaction is invalid.  
 * The signer of the transaction must be an agent in the Pike state and must
 belong to an organization in Pike state, otherwise the transaction is invalid.
-* The owner in the product must match the organization that the agent belongs to, otherwise the transaction is invalid.  
+* The owner in the product must match the organization that the agent belongs 
+to, otherwise the transaction is invalid.  
 * The agent must have the permission can_update_product for the organization,
 otherwise the transaction is invalid.
-* The new properties must be valid for the product_namespace.  For example, if the product is GS1 product, its properties must only contain properties that are included in the GS1 Schema. If it includes a property not in the GS1 Scheme the transaction is invalid.
+* The new properties must be valid for the product_namespace.  For example, if 
+the product is GS1 product, its properties must only contain properties that 
+are included in the GS1 Schema. If it includes a property not in the GS1 
+Scheme the transaction is invalid.
   
 _The base GS1 schema will be defined in a future RFC._
 
@@ -370,8 +380,10 @@ Validation requirements:
 * If a product with product_id does not exist the transaction is invalid.  
 * The signer of the transaction must be an agent in the Pike state and must
 belong to an organization in Pike state, otherwise the transaction is invalid.
-* The owner in the product must match the organization that the agent belongs to, otherwise the transaction is invalid.  
-* The agent must have the permission “can_delete_product” for the organization otherwise the transaction is invalid.
+* The owner in the product must match the organization that the agent belongs 
+to, otherwise the transaction is invalid.  
+* The agent must have the permission “can_delete_product” for the organization 
+otherwise the transaction is invalid.
 
 The inputs for ProductDeleteAction must include:
 

--- a/0000-product.md
+++ b/0000-product.md
@@ -102,14 +102,14 @@ Schema.
 
 ```
 message Product {
-enum ProductType {
-UNSET_TYPE = 0;
-GS1 = 1;
-}
-ProductType product_type = 1;
-string identifier = 2;
-string owner = 3;
-repeated PropertyValue properties = 4;
+    enum ProductType {
+        UNSET_TYPE = 0;
+        GS1 = 1;
+    }
+    ProductType product_type = 1;
+    string identifier = 2;
+    string owner = 3;
+    repeated PropertyValue properties = 4;
 }
 ```
 
@@ -141,8 +141,8 @@ Prefix, on page 20 of the GS1 General Specifications.
 Products are uniquely referenced by their product type and identifier. 
 For GS1, Products are referenced by the GTIN identifier. For example:
 ```
-get_gs1_product(GTIN)
-set_gs1_product(GTIN, GS1Product)
+    get_gs1_product(GTIN)
+    set_gs1_product(GTIN, GS1Product)
 ```
 
 ### Product Addressing in the Merkle-Radix State System
@@ -158,7 +158,7 @@ indicating “Products” and an additional “01” indicating “GS1 Products�
 
 Therefore, all addresses starting with:
 ```
-“621dee” + “02” + “01”
+    “621dee” + “02” + “01”
 ```
 are Grid GS1 Products identified by a GTIN and are expected to contain a
 Product representation which conforms with the GS1 product schema.
@@ -175,14 +175,14 @@ storage associated with the GS1 Product representation,
 for example:
 
 ```
-“621dee” + “02” + “01” + “00000000000000000000000000000000000000000000” +
-14-character “numeric string” GTIN + “00”
+    “621dee” + “02” + “01” + “00000000000000000000000000000000000000000000” +
+    14-character “numeric string” GTIN + “00”
 ```
 
 A full GS1 Product address using the example GTIN from https://www.gtin.info/
 would therefore be:
 ```
-“621dee0201000000000000000000000000000000000000000000000001234560001200”
+    “621dee0201000000000000000000000000000000000000000000000001234560001200”
 ```
 
 ## Transaction Payload and Execution
@@ -197,18 +197,18 @@ defined in the ProductPayload.
 
 ```
 message ProductPayload {
-enum Actions {
-UNSET_ACTION = 0;
-PRODUCT_CREATE = 1;
-PRODUCT_UPDATE = 2;
-PRODUCT_DELETE = 3;
-}
+    enum Actions {
+        UNSET_ACTION = 0;
+        PRODUCT_CREATE = 1;
+        PRODUCT_UPDATE = 2;
+        PRODUCT_DELETE = 3;
+    }
 
-Action action = 1;
+    Action action = 1;
 
-ProductCreateAction product_create = 2;
-ProductUpdateAction product_update = 3;
-ProductDeleteAction product_delete = 4;
+    ProductCreateAction product_create = 2;
+    ProductUpdateAction product_update = 3;
+    ProductDeleteAction product_delete = 4;
 }
 ```
 
@@ -223,15 +223,15 @@ contract.)
 
 ```
 message ProductCreateAction {
-enum ProductType {
-UNSET_TYPE = 0;
-GS1 = 1;
-}
-// product_type and identifier are used in deriving the state address
-ProductType product_type = 1;
-string identifier = 2;
-string owner = 3;
-repeated PropertyValues properties = 4;
+    enum ProductType {
+        UNSET_TYPE = 0;
+        GS1 = 1;
+    }
+    // product_type and identifier are used in deriving the state address
+    ProductType product_type = 1;
+    string identifier = 2;
+    string owner = 3;
+    repeated PropertyValues properties = 4;
 }
 ```
 
@@ -272,15 +272,15 @@ behalf of an organization that corresponds to the owner in the product being
 updated. (Organizations and agents are defined by the Pike smart contract.)
 ```
 message ProductUpdateAction {
-enum ProductType {
-UNSET_TYPE = 0;
-GS1 = 1;
-}
-// product_type and identifier are used in deriving the state address
-ProductType product_type = 1;
-string identifier = 2;
-// this will replace all properties currently defined
-repeated PropertyValues properties = 3;
+    enum ProductType {
+        UNSET_TYPE = 0;
+        GS1 = 1;
+    }
+    // product_type and identifier are used in deriving the state address
+    ProductType product_type = 1;
+    string identifier = 2;
+    // this will replace all properties currently defined
+    repeated PropertyValues properties = 3;
 }
 ```
 
@@ -319,14 +319,14 @@ behalf of the organization that corresponds to the org_id in the product being
 updated. (Organizations and agents are defined by the Pike smart contract.)
 ```
 message ProductDeleteAction {
-enum ProductType {
-UNSET_TYPE = 0;
-GS1 = 1;
-}
-// product_type and identifier are used in deriving the state address
-ProductType product_type = 1;    
-string identifier = 2;
-}
+    enum ProductType {
+        UNSET_TYPE = 0;
+        GS1 = 1;
+    }
+    // product_type and identifier are used in deriving the state address
+    ProductType product_type = 1;	
+    string identifier = 2;
+ }
 ```
 If the grid setting grid.product.allow_delete is set to false, this transaction
 is invalid. The default value for grid.product.allow_delete is true.This
@@ -358,10 +358,10 @@ An initial set of GS1 properties will be predefined within Grid. Each property
 will have a property definition of the following format:
 ```
 PropertyDefinition(
-name="<GSI Application Identifier>",
-data_type=PropertyDefinition.DataType.STRING,
-required=False,
-description="A description of the GS1 data."
+    name="<GSI Application Identifier>",
+    data_type=PropertyDefinition.DataType.STRING,
+    required=False,
+    description="A description of the GS1 data."
 )
 ```
 

--- a/0000-product.md
+++ b/0000-product.md
@@ -28,7 +28,7 @@ between participants. Product is a near universal concept within supply chain
 solutions and would naturally be one of the highest areas of re-use across Grid
 applications.
 
-The desgn will address use cases including:
+The design will address use cases including:
 
 - Sharing of Product master data across a network
 - Including Product in other business transactions (track and trace events,
@@ -389,8 +389,9 @@ PropertyDefinition(
 # Drawbacks
 [drawbacks]: #drawbacks
 
+
 Each GTIN format, except GTIN-8, contains an GS1 Company Prefix organizational
-identifier encoded into it, and this RFC duplicates the organization
+identifier encoded into it. and this RFC duplicates the organization
 identification with a Grid-specific owner field to tie the product to
 organizations managed in Pike. In the future, it may be good to use the GTIN’s
 organizational identifier directly.
@@ -406,15 +407,23 @@ The GS1 Company Prefix will be stored in the metadata under
 “gs1_company_prefix”.
 
 Solving how to properly provide GS1 Company Prefixes to a Pike Organization will
-be solved in a future RFC.
+be solved in a future RFC. This future RFC should integrate the concepts of GLN and the smart contract associated with grid gs1 product should be updated to reflect that integration.
+`
 
 Trade items can include non-material goods, such as services, which will also
 need to be represented within Grid. This is not covered by this RFC.
+
+Some examples of non-material goods: 
+
+- Batch/Lot (LGTIN) or Serialized (SGTIN) 
+- Logistical Cases/Pallets - Higher levels of packaging of the items - some of which are the trade unit between to parties although not necessarily the consumer unit. Identified sometimes with a GTIN but often times, due to their heterogeneous nature, with another GS1 identifier (SSCC).
+- Assets (returnable or fixed) - Identified with GRAI or GIAI - I presume like services (GSRN) OUT
 
 To expand the product schema to support all GS1 properties as well as keeping it
 all organized, there will need to be some refactoring done at the grid primitive
 level to support lists in the schema.
 
+This implementation does not account for transfer-of-ownership scenarios, and should be implemented as a supplemental RFC at a later time. See: https://github.com/hyperledger/grid-rfcs/pull/5#discussion_r312211331
 
 # Rationale and alternatives
 [alternatives]: #alternatives

--- a/0000-product.md
+++ b/0000-product.md
@@ -1,6 +1,6 @@
-Feature Name: Product
-Start Date: TBD
-RFC PR: TBD
+Feature Name: Product  
+Start Date: 5/13/19  
+RFC PR: [#5](https://github.com/hyperledger/grid-rfcs/pull/5)
 
 # Summary
 [summary]: #summary
@@ -10,7 +10,9 @@ Grid.
 GS1 is a widely used data standard in enterprises and, given that positioning
 and familiarity, Grid support feels natural. 
 Additional implementations of Product for specialized industries or use cases
-may derive from or extend this implementation.
+may derive from or extend this implementation. _For the base implementation of a
+product on grid, there will be 2 fields. Gtin and a repeated key-value field._
+
 
 # Motivation
 [motivation]: #motivation
@@ -70,7 +72,8 @@ state.
 Creation of GS1 products is restricted to agents acting on behalf of the
 organization that is associated with the GS1 company prefix encoded in the
 GTIN. 
-An organization must have the GS1 company prefix in the “gs1_company_prefixes”
+An organization must have the GS1 company prefix in the
+“gs1_company_prefixes”
 metadata field for its Pike organization. (Organization-level metadata will
 need to be implemented in Pike.) 
 When a product is created, its owning organization is stored with the project
@@ -157,8 +160,10 @@ Product representation.
 All Grid addresses are prefixed by the 6-hex-character namespace prefix
 “621dee”,  
 Products are further prefixed under the Grid namespace with reserved
-enumerations of “02” (“00” and “01” being reserved for other purposes)
-indicating “Products” and an additional “01” indicating “GS1 Products”. 
+enumerations of “02” (“00” and “01” being reserved for other
+purposes)
+indicating “Products” and an additional “01” indicating “GS1
+Products”. 
 
 Therefore, all addresses starting with:
 ```
@@ -167,8 +172,10 @@ Therefore, all addresses starting with:
 are Grid GS1 Products identified by a GTIN and are expected to contain a
 Product representation which conforms with the GS1 product schema.
 
-GTIN formats consist of 14-digit “numeric strings” which include some amount of
-internal “0” padding depending on the specific GTIN format (GTIN-8, GTIN-12,
+GTIN formats consist of 14-digit “numeric strings” which include some amount
+of
+internal “0” padding depending on the specific GTIN format (GTIN-8,
+GTIN-12,
 GTIN-13, or GTIN-14). 
 After the 10-hex-characters that are consumed by the grid namespace prefix, the
 product, and GS1 prefixes, there are 60 hex characters remaining in the
@@ -179,14 +186,15 @@ storage associated with the GS1 Product representation,
 for example:
 
 ```
-    “621dee” + “02” + “01” + “00000000000000000000000000000000000000000000” +
+    “621dee” + “02” + “01” +“00000000000000000000000000000000000000000000” +
     14-character “numeric string” GTIN + “00”
 ```
 
 A full GS1 Product address using the example GTIN from https://www.gtin.info/
 would therefore be:
 ```
-    “621dee0201000000000000000000000000000000000000000000000001234560001200”
+   
+“621dee0201000000000000000000000000000000000000000000000001234560001200”
 ```
 
 ## Transaction Payload and Execution
@@ -256,6 +264,7 @@ The properties must be valid for the product type. For example, if the product
 is GS1 product, its properties must only 
 contain properties that are included in the GS1 Schema. If it includes a
 property not in the GS1 Schema the transaction is invalid. 
+_The base GS1 schema will be defined in a future RFC._
 
 The product will be set in state.
 
@@ -346,7 +355,8 @@ belong to an organization in Pike state, otherwise the transaction is invalid.
 The owner in the product must match the organization that the agent belongs to,
 otherwise the transaction is invalid.
 
-The agent must have the permission “can_delete_product” for the organization,
+The agent must have the permission “can_delete_product” for the
+organization,
 otherwise the transaction is invalid.
 
 The inputs for ProductDeleteAction must include:
@@ -362,35 +372,12 @@ An initial set of GS1 properties will be predefined within Grid. Each property
 will have a property definition of the following format:
 ```
 PropertyDefinition(
-    name="<GSI Application Identifier>",
+    name="<GS1 Property>",
     data_type=PropertyDefinition.DataType.STRING,
     required=False,
     description="A description of the GS1 data."
 )
 ```
-
-The list of predefined properties from the GS1 Spec:
-
-| GS1 Application Identifier    | Description            | 
-| ------------- |:-------------:| 
-| 334                           | Area in Square metres  |
-| 353                           | Area in Square inches  |
-| 354                           | Area in Square feet    |
-| 355                           | Area in Square yards   |
-| 311                           | Length in metres       |
-| 341                           | Length in inches       |
-| 342                           | Length in feet         |
-| 343                           | Length in yards        |
-| 312                           | Width in metres        |
-| 324                           | Width in inches        |
-| 325                           | Width in feet          |
-| 326                           | Width in yards         |
-| 313                           | Height in meters       |
-| 327                           | Height in inches       |
-| 328                           | Height in feet         |
-| 329                           | Height in yards        |
-| 422                           | Country of Origin      |
-| 330                           | Gross weight           |
 
 # Drawbacks
 [drawbacks]: #drawbacks
@@ -398,8 +385,9 @@ The list of predefined properties from the GS1 Spec:
 Each GTIN format, except GTIN-8, contains an GS1 Company Prefix organizational
 identifier encoded into it, and this RFC duplicates the organization
 identification with a Grid-specific owner field to tie the product to
-organizations managed in Pike. In the future, it may be good to use the GTIN’s
-organizational identifier directly.
+organizations managed in Pike. In the future, it may be good to use the
+GTIN’s
+organizational identifier directly. 
 
 Currently, Pike does not provide a place to store a GS1 Company Prefix, and the
 permissions around who is authorized to provide this prefix is complicated and
@@ -417,22 +405,19 @@ will be solved in a future RFC.
 Trade items can include non-material goods, such as services, which will also
 need to be represented within Grid. This is not covered by this RFC.
 
-To expand the product schema to support all GS1 app id’s as well as keeping it
+To expand the product schema to support all GS1 properties as well as keeping
+it
 all organized, there will need to be some refactoring done at the grid
 primitive level to support lists in the schema. 
-
-Currently, we will **__exclude clothing, and furniture__** from the product
-properties. Keeping the focus on food items for the initial implementation of
-product.
 
 
 # Rationale and alternatives
 [alternatives]: #alternatives
 
-Starting with just capturing food items allows us to figure out the
-complexities associated with products in general. By starting with the GS1
-standards/app identifiers for produce (food) products, we will be able to
-iterate and get it right for one product space before moving on to others. i.e.
+Starting with capturing a base product allows us to later extend the definition
+with the
+complexities associated with products in general. We will be able to iterate and
+develop extensible product/schema definitions for each product space i.e.
 clothing, furniture, etc.
 
 Some details on products that can be used for a future iteration: 
@@ -475,4 +460,3 @@ Types](https://github.com/hyperledger/sawtooth-rfcs/blob/master/text/0013-supply
 
 # Unresolved questions
 [unresolved]: #unresolved-questions
-

--- a/0000-product.md
+++ b/0000-product.md
@@ -11,7 +11,8 @@ GS1 is a widely used data standard in enterprises and, given that positioning
 and familiarity, Grid support feels natural. 
 Additional implementations of Product for specialized industries or use cases
 may derive from or extend this implementation. _For the base implementation of a
-product on grid, there will be 4 fields. An identifier (gtin), a type (GS1), an owner (organization) and a repeated key-value field._
+product on grid, there will be 4 fields. An identifier (gtin), a type (GS1), an 
+owner (organization) and a repeated key-value field._
 
 
 # Motivation
@@ -91,6 +92,15 @@ enabled/disabled by a Grid administrator.
 Disabling delete is useful because external systems may have references to
 these products and deleting them could leave dangling references.
 
+## GTIN Validation
+Creation of a resuable gtin validation function to programmatically express the 
+equation used to validate a GTIN. It validates gtin format to avoid mistype 
+errors similar to a credit card validation. Implemented as an extensible 
+function if further validation steps are needed.
+Check digit validation: 
+(https://www.gs1.org/services/how-calculate-check-digit-manually)
+
+
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
@@ -128,7 +138,8 @@ supported in the future.)
 The GS1 GTIN specification is documented in section 3.3.2, Identification of a
 trade item (GTIN): AI (01), on page 140 of the **GS1 General Specification**: 
 
-https://www.gs1.org/sites/default/files/docs/barcodes/GS1_General_Specifications.pdf
+https://www.gs1.org/sites/default/files/docs/barcodes/GS1_General_Specifications
+.pdf
 
 The GS1-8 prefix is a unique string of 3 digits, and the GS1 company prefix
 consists of 4-12 digits. 
@@ -345,7 +356,8 @@ If the grid setting grid.product.allow_delete is set to false, this transaction
 is invalid. The default value for grid.product.allow_delete is true.This
 setting is stored using the Sawtooth Settings smart contract, more information
 can be found here
-https://sawtooth.hyperledger.org/docs/core/releases/latest/transaction_family_specifications/settings_transaction_family.html
+https://sawtooth.hyperledger.org/docs/core/releases/latest/transaction_family_sp
+ecifications/settings_transaction_family.html
 
 If a product with identifier does not exist the transaction is invalid.
 
@@ -422,7 +434,8 @@ clothing, furniture, etc.
 
 Some details on products that can be used for a future iteration: 
 [GS1 Apparel and General
-Merchandise](https://www.gs1us.org/DesktopModules/Bring2mind/DMX/Download.aspx?Command=Core_Download&EntryId=1067&language=en-US&PortalId=0&TabId=134)
+Merchandise](https://www.gs1us.org/DesktopModules/Bring2mind/DMX/Download.aspx?C
+ommand=Core_Download&EntryId=1067&language=en-US&PortalId=0&TabId=134)
 
 ### Clothing:
 Material content:  
@@ -447,18 +460,24 @@ Look at section 3.5.7 Packaging component number AI (243)
 
 ### Possible payload modifications:
 
-The owner field is not a _HARD_ requirement in in the product_state.prito. The owner (organization) could later be derived from the gtin, as we learn more about gtins and integrate some type of lookup functionality. That functionality is not included in this RFC. Would be a nice to have, but certainly not a MVP requirement.
+The owner field is not a _HARD_ requirement in in the product_state.prito. The 
+owner (organization) could later be derived from the gtin, as we learn more 
+about gtins and integrate some type of lookup functionality. That functionality 
+is not included in this RFC. Would be a nice to have, but certainly not a MVP 
+requirement.
 
 
 # Prior Art
 [prior-art]: #prior-art
 
 [Pike Transaction Family
-Specification](https://github.com/hyperledger/sawtooth-sabre/blob/master/contracts/sawtooth-pike/docs/source/pike_transaction_family.rst)
+Specification](https://github.com/hyperledger/sawtooth-sabre/blob/master/contrac
+ts/sawtooth-pike/docs/source/pike_transaction_family.rst)
 
 The Sawtooth Supply Chain mechanism to define field types.
 [Sawtooth Supply Chain Expanded Data
-Types](https://github.com/hyperledger/sawtooth-rfcs/blob/master/text/0013-supply-chain-expand-data-types.md)
+Types](https://github.com/hyperledger/sawtooth-rfcs/blob/master/text/0013-supply
+-chain-expand-data-types.md)
 
 
 

--- a/0000-product.md
+++ b/0000-product.md
@@ -353,8 +353,8 @@ can be found
 
 Validation requirements:
 
-* If a product with product_id does not exist the transaction is invalid.  The
-* signer of the transaction must be an agent in the Pike state and must
+* If a product with product_id does not exist the transaction is invalid.  
+* The signer of the transaction must be an agent in the Pike state and must
 belong to an organization in Pike state, otherwise the transaction is invalid.
 * The owner in the product must match the organization that the agent belongs to, otherwise the transaction is invalid.  
 * The agent must have the permission “can_delete_product” for the organization,

--- a/0000-product.md
+++ b/0000-product.md
@@ -49,10 +49,7 @@ within Grid.
 ## Entities
 
 A **__product__** is an archetype of an item that is transacted, traded, or
-referenced in a supply chain.  Each product has a **__product_type__**. This
-RFC defines a single product_namespace for GS1; a product of the GS1 product_namespace is
-called a GS1 product.  Note that this design supports extending additional
-product types in the future.
+referenced in a supply chain.  Each product has a **__product_namespace__**. This RFC defines a single product_namespace for GS1; a product in the GS1 product_namespace is called a GS1 product.  Note that this design supports extending additional product namespaces in the future.
 
 A product is referenced using a **product_id**.  For GS1 products,
 the product_id is a Global Trade Item Number (GTIN), which is part of
@@ -67,9 +64,7 @@ component of Grid).
 A product has one or more **properties**.  Properties are described in the Grid
 Primitives RFC.  A *property namespace* contains multiple *property
 schemas*.  A property schema associates a name (such as “length”) with a data
-type
-(such as integer).  GS1 products may only include properties defined in the GS1
-product property namespace.
+type (such as integer).  GS1 products may only include properties defined in the GS1 product property namespace.
 
 ## Transactions
 
@@ -277,7 +272,7 @@ The inputs for ProductCreateAction must include:
 
 * Address of the Agent submitting the transaction
 * Address of the Organization the Product is being created for
-* Address of the Product Type Schema the  product’s properties must match
+* Address of the Product Namespace Schema the product’s properties must match
 * Address of the Product to be created
 
 The outputs for ProductCreateAction must include:
@@ -324,7 +319,7 @@ The inputs for ProductUpdateAction must include:
 
 * Address of the Agent submitting the transaction
 * Address of the Organization the Product is being updated for
-* Address of the Product Type Schema the product’s properties must match
+* Address of the Product Namespace Schema the product’s properties must match
 * Address of the Product to be updated
 
 The outputs for ProductUpdateAction must include:

--- a/0000-product.md
+++ b/0000-product.md
@@ -11,7 +11,7 @@ GS1 is a widely used data standard in enterprises and, given that positioning
 and familiarity, Grid support feels natural. 
 Additional implementations of Product for specialized industries or use cases
 may derive from or extend this implementation. _For the base implementation of a
-product on grid, there will be 3 fields. An identifier (gtin), a type (GS1), and a repeated key-value field._
+product on grid, there will be 4 fields. An identifier (gtin), a type (GS1), an owner (organization) and a repeated key-value field._
 
 
 # Motivation
@@ -292,8 +292,6 @@ message ProductUpdateAction {
     // product_type and identifier are used in deriving the state address
     ProductType product_type = 1;
     string identifier = 2;
-    // product owner is used to validate the signing agents organization
-    string owner = 3;
     // this will replace all properties currently defined
     repeated PropertyValues properties = 4;
 }
@@ -341,8 +339,6 @@ message ProductDeleteAction {
     // product_type and identifier are used in deriving the state address
     ProductType product_type = 1;
     string identifier = 2;
-    // product owner is used to validate the signing agents organization
-    string owner = 3;
  }
 ```
 If the grid setting grid.product.allow_delete is set to false, this transaction
@@ -451,7 +447,7 @@ Look at section 3.5.7 Packaging component number AI (243)
 
 ### Possible payload modifications:
 
-The owner field is not a _HARD_ requirement for ProductUpdateAction and ProductDeleteAction in the product_payload. The owner (organization) could later be derived from the gtin, as we learn more about gtins and integrate some type of lookup functionality. That functionality is not included in this RFC. Would be a nice to have, but certainly not a MVP requirement.
+The owner field is not a _HARD_ requirement in in the product_state.prito. The owner (organization) could later be derived from the gtin, as we learn more about gtins and integrate some type of lookup functionality. That functionality is not included in this RFC. Would be a nice to have, but certainly not a MVP requirement.
 
 
 # Prior Art

--- a/0000-product.md
+++ b/0000-product.md
@@ -99,8 +99,8 @@ references to these products and deleting them could leave dangling references.
 
 Creation of a resuable gtin validation function to programmatically express the
 equation used to validate a GTIN. It validates gtin format to avoid mistype
-errors similar to a credit card validation. Implemented as an extensible
-function if further validation steps are needed.  Check digit validation:
+errors similar to a credit card validation. It's implemented as an extensible
+function such that further validation steps can be added, if needed.  Check digit validation:
 (https://www.gs1.org/services/how-calculate-check-digit-manually)
 
 
@@ -159,8 +159,8 @@ Products are uniquely referenced by their product type and identifier.  For
 GS1, Products are referenced by the GTIN identifier. For example:
 
 ```
-    get_product(GTIN)
-    set_product(GTIN, GS1Product)
+    get_product(identifier) // GTIN
+    set_product(identifier, product) // GTIN, gs1Product
 ```
 
 ### Product Addressing in the Merkle-Radix State System
@@ -194,7 +194,7 @@ representation, for example:
 
 ```
     “621dee” + “02” + “01” +“00000000000000000000000000000000000000000000” +
-    14-character “numeric string” GTIN + “00”
+    14-character “numeric string” identifier + “00” // identifier == GTIN
 ```
 
 A full GS1 Product address using the example GTIN from https://www.gtin.info/
@@ -462,8 +462,7 @@ Look at section 3.5.7 Packaging component number AI (243)
 The owner field is not a _HARD_ requirement in in the product_state.proto. The
 owner (organization) could later be derived from the gtin, as we learn more
 about gtins and integrate some type of lookup functionality. That functionality
-is not included in this RFC. Would be a nice to have, but certainly not a MVP
-requirement.
+is not included in this RFC and could be implemented at a later time.
 
 # Prior Art
 [prior-art]: #prior-art

--- a/0000-product.md
+++ b/0000-product.md
@@ -10,13 +10,14 @@ This RFC proposes a generic and extensible framework for a Hyperledger Grid
 Product entity as well as a more specific - and fully encapsulated - GS1
 compliant Product.
 
-GS1 is a widely used data standard in enterprises and, given that
-positioning and familiarity, Grid support feels natural.  Additional
-implementations of Product for specialized industries or use cases may derive
-from or extend this implementation.
+GS1 is a widely used data standard in enterprises and, given that positioning
+and familiarity, Grid support feels natural.  Additional implementations of
+Product for specialized industries or use cases may derive from or extend this
+implementation.
 
-_For the base implementation of a product
-on grid, there will be 4 fields. A product_id, a product_namespace, an owner, and properties (a repeated key-value field)._
+_For the base implementation of a product on grid, there will be 4 fields. A
+product_id, a product_namespace, an owner, and properties (a repeated key-value
+field)._
 
 
 # Motivation
@@ -31,17 +32,16 @@ The design will address use cases including:
 
 - Sharing of Product master data across a network
 - Including Product in other business transactions (track and trace events,
-purchases, sales, etc)
-- Enriching UX experiences by including additional attribution of a Product
-such as names or descriptions
+  purchases, sales, etc)
+- Enriching UX experiences by including additional attribution of a Product such
+  as names or descriptions
 
-It is also useful to use product information as
-auxiliary data in other supply chain solutions.  For example, in track and
-trace, the location and temperature of an item (an instance of a product) is
-stored.  When presenting this information later to a human user, it is useful
-to combine it with information about the product, such as the product’s name
-and description.  Therefore, Product becomes a reusable and important component
-within Grid.
+It is also useful to use product information as auxiliary data in other supply
+chain solutions.  For example, in track and trace, the location and temperature
+of an item (an instance of a product) is stored.  When presenting this
+information later to a human user, it is useful to combine it with information
+about the product, such as the product’s name and description.  Therefore,
+Product becomes a reusable and important component within Grid.
 
 # Guide-Level Explanation
 [guide-level-explanation]: #guide-level-explanation
@@ -49,22 +49,26 @@ within Grid.
 ## Entities
 
 A **__product__** is an archetype of an item that is transacted, traded, or
-referenced in a supply chain.  Each product has a **__product_namespace__**. This RFC defines a single product_namespace for GS1; a product in the GS1 product_namespace is called a GS1 product.  Note that this design supports extending additional product namespaces in the future.
+referenced in a supply chain.  Each product has a **__product_namespace__**.
+This RFC defines a single product_namespace for GS1; a product in the GS1
+product_namespace is called a GS1 product.  Note that this design supports
+extending additional product namespaces in the future.
 
-A product is referenced using a **product_id**.  For GS1 products,
-the product_id is a Global Trade Item Number (GTIN), which is part of
-the GS1 specifications.
+A product is referenced using a **product_id**.  For GS1 products, the
+product_id is a Global Trade Item Number (GTIN), which is part of the GS1
+specifications.
 
 Each product has an **__owner__**, which is the identifier of the organization
 responsible for maintaining the product.  An **__agent__** acts on behalf of an
-organization, and all permissions are defined in terms of the actions agents
-can perform.  Organizations and agents are defined and managed by Pike (another
+organization, and all permissions are defined in terms of the actions agents can
+perform.  Organizations and agents are defined and managed by Pike (another
 component of Grid).
 
 A product has one or more **properties**.  Properties are described in the Grid
-Primitives RFC.  A *property namespace* contains multiple *property
-schemas*.  A property schema associates a name (such as “length”) with a data
-type (such as integer).  GS1 products may only include properties defined in the GS1 product property namespace.
+Primitives RFC.  A *property namespace* contains multiple *property schemas*.  A
+property schema associates a name (such as “length”) with a data type (such as
+integer).  GS1 products may only include properties defined in the GS1 product
+property namespace.
 
 ## Transactions
 
@@ -72,24 +76,23 @@ Products are managed by submitting transactions to Hyperledger Grid, which will
 process them with the Grid Product smart contract. The following transactions
 are supported:
 
-* ProductCreate - create a Product and store it in state.
-* ProductUpdate - update (replace) the properties of a Product already in
+* ProductCreate - create a Product and store it in state.  ProductUpdate -
+* update (replace) the properties of a Product already in
   state.
 * ProductDelete - remove a Product from state.
 
 ## Permissions
 
 Creation of GS1 products is restricted to agents acting on behalf of the
-organization that is associated with the GS1 company prefix encoded in the
-GTIN.  An organization must have the GS1 company prefix in the
-“gs1_company_prefixes” metadata field for its Pike organization.
-(Organization-level metadata will need to be implemented in Pike.) When
-a product is created, its owning organization is stored with the product in an
-“owner” field.
+organization that is associated with the GS1 company prefix encoded in the GTIN.
+An organization must have the GS1 company prefix in the “gs1_company_prefixes”
+metadata field for its Pike organization.  (Organization-level metadata will
+need to be implemented in Pike.) When a product is created, its owning
+organization is stored with the product in an “owner” field.
 
-Updates to products is restricted to agents acting on behalf of the
-organization stored in the product’s owner field.  Only property fields can be
-updated. Product_id, product_namespace, and owner fields are immutable.
+Updates to products is restricted to agents acting on behalf of the organization
+stored in the product’s owner field.  Only property fields can be updated.
+Product_id, product_namespace, and owner fields are immutable.
 
 Deletion of products is restricted to agents acting on behalf of the
 organization in the product’s owner field.  A setting will turn off deletion
@@ -102,8 +105,9 @@ references to these products and deleting them could leave dangling references.
 Creation of a resuable gtin validation function to programmatically express the
 equation used to validate a GTIN. It validates gtin format to avoid mistype
 errors similar to a credit card validation. It's implemented as an extensible
-function such that further validation steps can be added, if needed. For details on the equation see: [Check
-digit validation](https://www.gs1.org/services/how-calculate-check-digit-manually).
+function such that further validation steps can be added, if needed. For details
+on the equation see: [Check digit
+validation](https://www.gs1.org/services/how-calculate-check-digit-manually).
 
 
 # Reference-level explanation
@@ -113,64 +117,52 @@ digit validation](https://www.gs1.org/services/how-calculate-check-digit-manuall
 
 ### Product Representation
 
-The primary object stored in state is “Product”, which consists of an
-product_id (GS1 GTIN), an owner (org_id compatible w/Pike),
-and a list of property name/value pairs.  The properties available are defined
-by the Grid Property Schema Transaction Family and are restricted to the fields
-and rules of the GS1 Product schema.  Transactions which are responsible for
-setting product state values must ensure that the properties conform with the
-requirements of the GS1 Product Property Schema.
+The primary object stored in state is “Product”, which consists of an product_id
+(GS1 GTIN), an owner (org_id compatible w/Pike), and a list of property
+name/value pairs.  The properties available are defined by the Grid Property
+Schema Transaction Family and are restricted to the fields and rules of the GS1
+Product schema.  Transactions which are responsible for setting product state
+values must ensure that the properties conform with the requirements of the GS1
+Product Property Schema.
 
-```
-message Product {
-    enum ProductNamespace {
-        UNSET_NAMESPACE = 0;
-        GS1 = 1;
-    }
-    string product_id = 1;
-    ProductNamespace product_namespace = 2;
-    string owner = 3;
-    repeated PropertyValue properties = 4;
-}
-```
+``` message Product { enum ProductNamespace { UNSET_NAMESPACE = 0; GS1 = 1; }
+string product_id = 1; ProductNamespace product_namespace = 2; string owner = 3;
+repeated PropertyValue properties = 4; } ```
 
-The GS1 GTIN is an identifier (product_id) used to identify trade items.  A
-GTIN is the data
-transmitted from a barcode scan and is made up of a company prefix (or GS1-8
-prefix) and item reference.  We will initially support GTIN-12, GTIN-13, and
-GTIN-14. (GTIN-8 may be supported in the future.) The GS1 GTIN specification is
-documented in section 3.3.2, Identification of a trade item (GTIN): AI (01), on
-page 140 of the **GS1 General Specification**:
+The GS1 GTIN is an identifier (product_id) used to identify trade items.  A GTIN
+is the data transmitted from a barcode scan and is made up of a company prefix
+(or GS1-8 prefix) and item reference.  We will initially support GTIN-12,
+GTIN-13, and GTIN-14. (GTIN-8 may be supported in the future.) The GS1 GTIN
+specification is documented in section 3.3.2, Identification of a trade item
+(GTIN): AI (01), on page 140 of the **GS1 General Specification**:
 
 https://www.gs1.org/sites/default/files/docs/barcodes/GS1_General_Specifications.pdf
 
 The GS1-8 prefix is a unique string of 3 digits, and the GS1 company prefix
-consists of 4-12 digits.  The GS1-8 prefixes is issued by the GS1 Global
-Office. The GS1-8 prefix is allocated to a GS1 member organization to issue the
-GTIN-8’s to other areas.  The GS1 company prefix can be issued by the GS1
-Global Office or a member organization. Usually issued to a company itself.
+consists of 4-12 digits.  The GS1-8 prefixes is issued by the GS1 Global Office.
+The GS1-8 prefix is allocated to a GS1 member organization to issue the GTIN-8’s
+to other areas.  The GS1 company prefix can be issued by the GS1 Global Office
+or a member organization. Usually issued to a company itself.
 
 Also relevant is the GS1-8 Prefix or GS1 Company Prefix which namespaces the
-GTIN by issuing organization.  GS1 manages the master data for company
-prefixes. Owning companies issue their own GTINs within their prefixed
-namespace.  Details about GS1 Company Prefixes can be found in section 1.4.4,
-GS1 Company Prefix, on page 20 of the GS1 General Specifications.
+GTIN by issuing organization.  GS1 manages the master data for company prefixes.
+Owning companies issue their own GTINs within their prefixed namespace.  Details
+about GS1 Company Prefixes can be found in section 1.4.4, GS1 Company Prefix, on
+page 20 of the GS1 General Specifications.
 
 ### Referencing Products
 
 Products are uniquely referenced by their product_id and product_namespace.  For
 GS1, Products are referenced by the GTIN identifier. For example:
 
-```
-    get_product(product_id) // GTIN
-    set_product(product_id, product) // GTIN, gs1Product
-```
+``` get_product(product_id) // GTIN set_product(product_id, product) // GTIN,
+gs1Product ```
 
 ### Product Addressing in the Merkle-Radix State System
 
 In order to uniquely locate GS1 products in the Merkle-Radix state system, an
-address must be constructed which identifies the storage location of the
-Product representation.
+address must be constructed which identifies the storage location of the Product
+representation.
 
 All Grid addresses are prefixed by the 6-hex-character namespace prefix
 “621dee”,  Products are further prefixed under the Grid namespace with reserved
@@ -179,33 +171,27 @@ indicating “Products” and an additional “01” indicating “GS1 Products�
 
 Therefore, all addresses starting with:
 
-```
-    “621dee” + “02” + “01”
-```
+``` “621dee” + “02” + “01” ```
 
-are Grid GS1 Products identified by a GTIN and are expected to contain
-a Product representation which conforms with the GS1 product schema.
+are Grid GS1 Products identified by a GTIN and are expected to contain a Product
+representation which conforms with the GS1 product schema.
 
 GTIN formats consist of 14-digit “numeric strings” which include some amount of
 internal “0” padding depending on the specific GTIN format (GTIN-8, GTIN-12,
-GTIN-13, or GTIN-14).  After the 10-hex-characters that are consumed by the
-grid namespace prefix, the product, and GS1 prefixes, there are 60 hex
-characters remaining in the address.  The 14 digits of the GTIN can be left
-padded with 44-hex-character zeroes and right padded with 2-hex-character
-zeroes to accommodate potential future storage associated with the GS1 Product
+GTIN-13, or GTIN-14).  After the 10-hex-characters that are consumed by the grid
+namespace prefix, the product, and GS1 prefixes, there are 60 hex characters
+remaining in the address.  The 14 digits of the GTIN can be left padded with
+44-hex-character zeroes and right padded with 2-hex-character zeroes to
+accommodate potential future storage associated with the GS1 Product
 representation, for example:
 
-```
-    “621dee” + “02” + “01” +“00000000000000000000000000000000000000000000” +
-    14-character “numeric string” product_id + “00” // product_id == GTIN
-```
+``` “621dee” + “02” + “01” +“00000000000000000000000000000000000000000000” +
+14-character “numeric string” product_id + “00” // product_id == GTIN ```
 
 A full GS1 Product address using the example GTIN from https://www.gtin.info/
 would therefore be:
 
-```
-“621dee0201000000000000000000000000000000000000000000000001234560001200”
-```
+``` “621dee0201000000000000000000000000000000000000000000000001234560001200” ```
 
 ## Transaction Payload and Execution
 
@@ -217,22 +203,13 @@ allows for the action payload to be dispatched to the appropriate logic.
 Only the defined actions are available and only one action payload should be
 defined in the ProductPayload.
 
-```
-message ProductPayload {
-    enum Actions {
-        UNSET_ACTION = 0;
-        PRODUCT_CREATE = 1;
-        PRODUCT_UPDATE = 2;
-        PRODUCT_DELETE = 3;
-    }
+``` message ProductPayload { enum Actions { UNSET_ACTION = 0; PRODUCT_CREATE =
+1; PRODUCT_UPDATE = 2; PRODUCT_DELETE = 3; }
 
     Action action = 1;
 
-    ProductCreateAction product_create = 2;
-    ProductUpdateAction product_update = 3;
-    ProductDeleteAction product_delete = 4;
-}
-```
+    ProductCreateAction product_create = 2; ProductUpdateAction product_update =
+3; ProductDeleteAction product_delete = 4; } ```
 
 ### ProductCreateAction
 
@@ -241,39 +218,35 @@ submitted by an agent, which is identified by its signing key, acting on behalf
 of the organization that corresponds to the owner in the create transaction.
 (Organizations and agents are defined by the Pike smart contract.)
 
-```
-message ProductCreateAction {
-    enum Product_Namespace {
-        UNSET_NAMESPACE = 0;
-        GS1 = 1;
-    }
+``` message ProductCreateAction { enum Product_Namespace { UNSET_NAMESPACE = 0;
+GS1 = 1; }
     // product_namespace and product_id are used in deriving the state address
-    Product_Namespace product_namespace = 1;
-    string product_id = 2;
-    string owner = 3;
-    repeated PropertyValues properties = 4;
-}
-```
+    Product_Namespace product_namespace = 1; string product_id = 2; string owner
+= 3; repeated PropertyValues properties = 4; } ```
 
 Validation requirements:
 
-* If a product with product_id already exists the transaction is invalid.
-* The signer of the transaction must be an agent in the Pike state and must
+* If a product with product_id already exists the transaction is invalid.  The
+* signer of the transaction must be an agent in the Pike state and must
 belong to an organization in Pike state, otherwise the transaction is invalid.
 The agent must have the permission can_create_product for the organization,
 otherwise the transaction is invalid.
-* If the product_namespace is GS1, the organization must contain a GS1 Company Prefix in its metadata (gs1_company_prefixes), and the prefix must match the company prefix in the product_id, which is a gtin if GS1, otherwise the transaction is invalid.
-* The properties must be valid for the product_namespace. For example, if the productis GS1 product, its properties must only contain properties that are includedin the GS1 Schema. If it includes a property not in the GS1 Schema the
+* If the product_namespace is GS1, the organization must contain a GS1 Company
+* Prefix in its metadata (gs1_company_prefixes), and the prefix must match the
+* company prefix in the product_id, which is a gtin if GS1, otherwise the
+* transaction is invalid.  The properties must be valid for the
+* product_namespace. For example, if the productis GS1 product, its properties
+* must only contain properties that are includedin the GS1 Schema. If it
+* includes a property not in the GS1 Schema the
 transaction is invalid.  _The base GS1 schema will be defined in a future RFC._
 
 The product will be set in state.
 
 The inputs for ProductCreateAction must include:
 
-* Address of the Agent submitting the transaction
-* Address of the Organization the Product is being created for
-* Address of the Product Namespace Schema the product’s properties must match
-* Address of the Product to be created
+* Address of the Agent submitting the transaction Address of the Organization
+* the Product is being created for Address of the Product Namespace Schema the
+* product’s properties must match Address of the Product to be created
 
 The outputs for ProductCreateAction must include:
 
@@ -281,34 +254,30 @@ The outputs for ProductCreateAction must include:
 
 ### ProductUpdateAction
 
-ProductUpdateAction updates an existing product in state. The transaction
-should be submitted by an agent, identified by its signing key, acting on
-behalf of an organization that corresponds to the owner in the product being
-updated. (Organizations and agents are defined by the Pike smart contract.)
+ProductUpdateAction updates an existing product in state. The transaction should
+be submitted by an agent, identified by its signing key, acting on behalf of an
+organization that corresponds to the owner in the product being updated.
+(Organizations and agents are defined by the Pike smart contract.)
 
-```
-message ProductUpdateAction {
-    enum Product_Namespace {
-        UNSET_NAMESPACE = 0;
-        GS1 = 1;
-    }
+``` message ProductUpdateAction { enum Product_Namespace { UNSET_NAMESPACE = 0;
+GS1 = 1; }
     // product_namespace and product_id are used in deriving the state address
-    Product_Namespace product_namespace = 1;
-    string product_id = 2;
+    Product_Namespace product_namespace = 1; string product_id = 2;
     // this will replace all properties currently defined
-    repeated PropertyValues properties = 4;
-}
-```
+    repeated PropertyValues properties = 4; } ```
 
 Validation requirements:
 
-* If a product with product_id does not exist the transaction is invalid.
-* The signer of the transaction must be an agent in the Pike state and must
+* If a product with product_id does not exist the transaction is invalid.  The
+* signer of the transaction must be an agent in the Pike state and must
 belong to an organization in Pike state, otherwise the transaction is invalid.
-* The owner in the product must match the organization that the agent belongs to, otherwise the transaction is invalid.
-* The agent must have the permission can_update_prouduct for the organization,
+* The owner in the product must match the organization that the agent belongs
+* to, otherwise the transaction is invalid.  The agent must have the permission
+* can_update_prouduct for the organization,
 otherwise the transaction is invalid.
-* The new properties must be valid for the product_namespace. For example, if theproduct is GS1 product, its properties must only contain properties that are
+* The new properties must be valid for the product_namespace. For example, if
+* theproduct is GS1 product, its properties must only contain properties that
+* are
 included in the GS1 Schema. If it includes a property not in the GS1 Scheme the
 transaction is invalid.
 
@@ -317,10 +286,9 @@ updated product will be set in state.
 
 The inputs for ProductUpdateAction must include:
 
-* Address of the Agent submitting the transaction
-* Address of the Organization the Product is being updated for
-* Address of the Product Namespace Schema the product’s properties must match
-* Address of the Product to be updated
+* Address of the Agent submitting the transaction Address of the Organization
+* the Product is being updated for Address of the Product Namespace Schema the
+* product’s properties must match Address of the Product to be updated
 
 The outputs for ProductUpdateAction must include:
 
@@ -329,41 +297,35 @@ The outputs for ProductUpdateAction must include:
 ### ProductDeleteAction
 
 ProductDeleteAction removes an existing product from state. The transaction
-should be submitted by an agent, identified by its signing key, acting on
-behalf of the organization that corresponds to the org_id in the product being
-updated. (Organizations and agents are defined by the Pike smart contract.)
+should be submitted by an agent, identified by its signing key, acting on behalf
+of the organization that corresponds to the org_id in the product being updated.
+(Organizations and agents are defined by the Pike smart contract.)
 
-```
-message ProductDeleteAction {
-    enum Product_Namespace {
-        UNSET_NAMESPACE = 0;
-        GS1 = 1;
-    }
+``` message ProductDeleteAction { enum Product_Namespace { UNSET_NAMESPACE = 0;
+GS1 = 1; }
     // product_namespace and product_id are used in deriving the state address
-    Product_Namespace product_namespace = 1;
-    string product_id = 2;
- }
-```
+    Product_Namespace product_namespace = 1; string product_id = 2; } ```
 
 If the grid setting grid.product.allow_delete is set to false, this transaction
 is invalid. The default value for grid.product.allow_delete is true. This
 setting is stored using the Sawtooth Settings smart contract, more information
-can be found [here](https://sawtooth.hyperledger.org/docs/core/releases/latest/transaction_family_specifications/settings_transaction_family.html).
+can be found
+[here](https://sawtooth.hyperledger.org/docs/core/releases/latest/transaction_family_specifications/settings_transaction_family.html).
 
 Validation requirements:
 
-* If a product with product_id does not exist the transaction is invalid.
-* The signer of the transaction must be an agent in the Pike state and must
+* If a product with product_id does not exist the transaction is invalid.  The
+* signer of the transaction must be an agent in the Pike state and must
 belong to an organization in Pike state, otherwise the transaction is invalid.
-* The owner in the product must match the organization that the agent belongs to, otherwise the transaction is invalid.
-* The agent must have the permission “can_delete_product” for the organization,
+* The owner in the product must match the organization that the agent belongs
+* to, otherwise the transaction is invalid.  The agent must have the permission
+* “can_delete_product” for the organization,
 otherwise the transaction is invalid.
 
 The inputs for ProductDeleteAction must include:
 
-* Address of the Agent submitting the transaction
-* Address of the Organization the Product is being deleted for
-* Address of the Product to be deleted
+* Address of the Agent submitting the transaction Address of the Organization
+* the Product is being deleted for Address of the Product to be deleted
 
 The outputs for ProductUpdateAction must include:
 
@@ -374,14 +336,9 @@ The outputs for ProductUpdateAction must include:
 An initial set of GS1 properties will be predefined within Grid. Each property
 will have a property definition of the following format:
 
-```
-PropertyDefinition(
-    name="<GS1 Property>",
-    data_type=PropertyDefinition.DataType.STRING,
-    required=False,
-    description="A description of the GS1 data."
-)
-```
+``` PropertyDefinition( name="<GS1 Property>",
+data_type=PropertyDefinition.DataType.STRING, required=False, description="A
+description of the GS1 data.") ```
 
 # Drawbacks
 [drawbacks]: #drawbacks
@@ -402,15 +359,15 @@ similar to Agent’s metadata. Metadata is a Key,Value store of arbitrary data.
 The GS1 Company Prefix will be stored in the metadata under
 “gs1_company_prefix”.
 
-Solving how to properly provide GS1 Company Prefixes to a Pike Organization
-will be solved in a future RFC.
+Solving how to properly provide GS1 Company Prefixes to a Pike Organization will
+be solved in a future RFC.
 
 Trade items can include non-material goods, such as services, which will also
 need to be represented within Grid. This is not covered by this RFC.
 
-To expand the product schema to support all GS1 properties as well as keeping
-it all organized, there will need to be some refactoring done at the grid
-primitive level to support lists in the schema.
+To expand the product schema to support all GS1 properties as well as keeping it
+all organized, there will need to be some refactoring done at the grid primitive
+level to support lists in the schema.
 
 
 # Rationale and alternatives
@@ -418,8 +375,8 @@ primitive level to support lists in the schema.
 
 Starting with capturing a base product allows us to later extend the definition
 with the complexities associated with products in general. We will be able to
-iterate and develop extensible product/schema definitions for each product
-space i.e.  clothing, furniture, etc.
+iterate and develop extensible product/schema definitions for each product space
+i.e.  clothing, furniture, etc.
 
 Some details on products that can be used for a future iteration: [GS1 Apparel
 and General
@@ -427,23 +384,19 @@ Merchandise](https://www.gs1us.org/DesktopModules/Bring2mind/DMX/Download.aspx?C
 
 ### Clothing:
 
-Material content:\
-This element is used to indicate the material composition.  This element is
-used in conjunction with the percentage.
+Material content:\ This element is used to indicate the material composition.
+This element is used in conjunction with the percentage.
 
-Material Percentage:\
-Net weight percentage of a product material of the first main material. The
-percentages must add up to 100.
+Material Percentage:\ Net weight percentage of a product material of the first
+main material. The percentages must add up to 100.
 
-Material Percentage:\
-Net weight percentage of a product material of the first main material. The
-percentages must add up to 100.
+Material Percentage:\ Net weight percentage of a product material of the first
+main material. The percentages must add up to 100.
 
 ### Furniture:
 
-Number of pieces:\
-The total number of separately packaged components comprising a single trade
-item.
+Number of pieces:\ The total number of separately packaged components comprising
+a single trade item.
 
 Look at section 3.5.7 Packaging component number AI (243)
 

--- a/0000-product.md
+++ b/0000-product.md
@@ -148,8 +148,8 @@ Prefix, on page 20 of the GS1 General Specifications.
 Products are uniquely referenced by their product type and identifier. 
 For GS1, Products are referenced by the GTIN identifier. For example:
 ```
-    get_gs1_product(GTIN)
-    set_gs1_product(GTIN, GS1Product)
+    get_product(GTIN)
+    set_product(GTIN, GS1Product)
 ```
 
 ### Product Addressing in the Merkle-Radix State System
@@ -292,8 +292,10 @@ message ProductUpdateAction {
     // product_type and identifier are used in deriving the state address
     ProductType product_type = 1;
     string identifier = 2;
+    // product owner is used to validate the signing agents organization
+    string owner = 3;
     // this will replace all properties currently defined
-    repeated PropertyValues properties = 3;
+    repeated PropertyValues properties = 4;
 }
 ```
 
@@ -339,6 +341,8 @@ message ProductDeleteAction {
     // product_type and identifier are used in deriving the state address
     ProductType product_type = 1;
     string identifier = 2;
+    // product owner is used to validate the signing agents organization
+    string owner = 3;
  }
 ```
 If the grid setting grid.product.allow_delete is set to false, this transaction
@@ -444,6 +448,10 @@ The total number of separately packaged components comprising a single trade
 item.
 
 Look at section 3.5.7 Packaging component number AI (243)
+
+### Possible payload modifications:
+
+The owner field is not a _HARD_ requirement for ProductUpdateAction and ProductDeleteAction in the product_payload. The owner (organization) could later be derived from the gtin, as we learn more about gtins and integrate some type of lookup functionality. That functionality is not included in this RFC. Would be a nice to have, but certainly not a MVP requirement.
 
 
 # Prior Art

--- a/0000-product.md
+++ b/0000-product.md
@@ -433,7 +433,11 @@ reflect that integration.  `
 Trade items can include non-material goods, such as services, which will also
 need to be represented within Grid. This is not covered by this RFC.
 
-Some examples of non-material goods: 
+GS1 identifiers not specified for trade items are not included in Grid. (Assets, 
+services) While logistical items (typically identified with an SSCC) may not be 
+in this RFC, I would not exclude it entirely from Grid.
+
+Some examples of material goods: 
 
 - Batch/Lot (LGTIN) or Serialized (SGTIN) 
 - Logistical Cases/Pallets - Higher levels of packaging of the items - some of

--- a/0000-product.md
+++ b/0000-product.md
@@ -1,3 +1,7 @@
+Feature Name: Product
+Start Date: TBD
+RFC PR: TBD
+
 # Summary
 [summary]: #summary
 
@@ -324,7 +328,7 @@ message ProductDeleteAction {
         GS1 = 1;
     }
     // product_type and identifier are used in deriving the state address
-    ProductType product_type = 1;	
+    ProductType product_type = 1;
     string identifier = 2;
  }
 ```

--- a/0000-product.md
+++ b/0000-product.md
@@ -456,7 +456,7 @@ Look at section 3.5.7 Packaging component number AI (243)
 
 ### Possible payload modifications:
 
-The owner field is not a _HARD_ requirement in in the product_state.prito. The 
+The owner field is not a _HARD_ requirement in in the product_state.proto. The 
 owner (organization) could later be derived from the gtin, as we learn more 
 about gtins and integrate some type of lookup functionality. That functionality 
 is not included in this RFC. Would be a nice to have, but certainly not a MVP 

--- a/0000-product.md
+++ b/0000-product.md
@@ -65,12 +65,17 @@ perform.  Organizations and agents are defined and managed by Pike (another
 component of Grid).
 
 A product has one or more **properties**.  Properties are described in the Grid
-Primitives RFC.  A *property namespace* contains multiple *property schemas*.  A
-property schema associates a name (such as “length”) with a data type (such as
-integer).  GS1 products may only include properties defined in the GS1 product
-property namespace.
+Primitives RFC.  The grid *schema namespace* will contain many *property schemas*.
+A property schema associates a name (such as “length”) with a data type (such as
+integer). A single entry in a schema is known as a PropertyDefinition.  GS1 
+products may only include properties defined in the GS1 product property 
+namespace.
 
 ## Transactions
+
+In order to add Products to state, a transaction must be used. The following 
+transactions and their execution rules are designed for the Hyperledger 
+Sawtooth platform and may differ for other transaction execution platforms.
 
 Products are managed by submitting transactions to Hyperledger Grid, which will
 process them with the Grid Product smart contract. The following transactions
@@ -94,8 +99,10 @@ need to be implemented in Pike.) When a product is created, its owning
 organization is stored with the product in an “owner” field.
 
 Updates to products is restricted to agents acting on behalf of the organization
-stored in the product’s owner field.  Only property fields can be updated.
-Product_id, product_namespace, and owner fields are immutable.
+stored in the product’s owner field.  Only property fields can be updated. They 
+are updated by providing a complete and updated list of the properties, and 
+overwrites the entire list of property values. Product_id, product_namespace, 
+and owner fields are immutable.
 
 Deletion of products is restricted to agents acting on behalf of the
 organization in the product’s owner field.  A setting will turn off deletion


### PR DESCRIPTION
This RFC proposes a GS1-compatible implementation of Product for Grid. The component is intended to initially serve as a base implementation of the product in accordance with the GS1 spec. The intention is to iterate on this product component and derive product types in the future (i.e. food item, clothing, furniture, etc)