### PR TITLE
Add Location RFC

### DIFF
--- a/text/0000-location.md
+++ b/text/0000-location.md
@@ -348,15 +348,15 @@ digital locations and should be implemented with supplemental RFC(s).
 |Contact Name|contactName| |"Jane Doe"|STRING| | |
 |Contact Email|contactEmail| |"jane_doe@example.com"|STRING| | |
 |Contact Phone|contactPhone|The location's primary phone number. Best practice is individual with assignment duty.|"937-435-3870"|STRING|1|30|
-|Create Date|createDate|Date this location becomes active.|"06/01/2015"| | | |
+|Create Date|createDate|Date this location becomes active.|"06/01/2015"|DATETIME| | |
 
 **_OPTIONAL FIELDS_**
 |GS1 Common Name|GS1 Attribute Name|Description|Example|Data Type|Min|Max|
 |---------------|------------------|-----------|-------|----|---|---|
 |Location Name 2|locationName2|A secondary facility name.|"Cargill Incorporated"|STRING|0|80|
 |Address Line 2|addressLine2|Any secondary information such as Suite, Floor, etc. The USPS address is validated if Country = United States.|"Suite 204"|STRING|0|80|
-|Address Line 3|addressLine3|Additional descriptive information that is not verified through the USPS data base. Best practice is to use AddressLine3 when there are multiple locations using the same USPS address. Examples: Billing office, cardiology lab, backroom, etc.| | | | |
-|Inactivation Date|inactivationDate|Date this location is no longer used by the information provider.|"01/15/2020"| | | |
+|Address Line 3|addressLine3|Additional descriptive information that is not verified through the USPS data base. Best practice is to use AddressLine3 when there are multiple locations using the same USPS address. Examples: Billing office, cardiology lab, backroom, etc.| |STRING| | |
+|Inactivation Date|inactivationDate|Date this location is no longer used by the information provider.|"01/15/2020"|DATETIME| | |
 |Parent Location GLN|parentLocation|Used to describe a location hierarchy. Needed for every GLN except the top-level location, which does not have a parent location.|"0653114000000"|NUMBER|13|13|
 |Industry Sector|industrySector|Select one option: General, CPG, Healthcare, Foodservice.|"Foodservice"|ENUM| | |
 |Supply Chain Role|role|Available options are based on the selected Industry Sector for this GLN. General: Manufacturer, Solutions Provider, Undefined. CPG: Manufacturer, Solutions Provider, Undefined. Healthcare: Distributor, Provider, Supplier, Undefined. Foodservice: 3rd Party, Warehouse, Distributor, Independent Operator, Manufacturer, Operator.|"Manufacturer"|ENUM| | |

--- a/text/0000-location.md
+++ b/text/0000-location.md
@@ -202,8 +202,8 @@ allows for the action payload to be dispatched to the appropriate logic.
 
 Only the defined actions are available and only one action payload should be 
 defined in the LocationPayload.
-    
-        message LocationPayload {        
+
+    message LocationPayload {
         enum Actions {
             UNSET_ACTION = 0;
             LOCATION_CREATE = 1;
@@ -219,6 +219,29 @@ defined in the LocationPayload.
         LocationCreateAction location_create = 3;
         LocationUpdateAction location_update = 4;
         LocationDeleteAction location_delete = 5;
+    }
+
+    message LocationCreateAction {
+        Location.LocationType location_type = 1;
+        string location_id = 2;
+        string owner = 3;
+        repeated PropertyValue properties = 4;
+    }
+
+    message LocationUpdateAction {
+        // Not modified. Only  used to find location object in state
+        Location.LocationType location_type = 1;
+        // Not modified. Only  used to find location object in state
+        string location_id = 2;
+        // This will replace all properties currently defined
+        repeated PropertyValue properties = 3;
+    }
+
+    message LocationDeleteAction {
+        // Not modified. Only  used to find location object in state
+        Location.LocationType location_type = 1;
+        // Not modified. Only  used to find location object in state
+        string location_id = 2;
     }
 
 ### LocationCreateAction

--- a/text/0000-location.md
+++ b/text/0000-location.md
@@ -65,11 +65,11 @@ covers all currently implemented DLT backends in Grid.
 Locations are managed by submitting transactions to Hyperledger Grid, which will
 process them with the Grid Location smart contract. The following transactions 
 are supported:
-- LocationCreate - create a Location and store it in state.
-- LocationUpdate - update (replace) the properties of a Location already in state.
-- LocationDelete - remove a Location from state.
+- `LocationCreateAction` - create a Location and store it in state.
+- `LocationUpdateAction` - update (replace) the properties of a Location already in state.
+- `LocationDeleteAction` - remove a Location from state.
  
-_*Disclaimer: LocationDelete is a potentially hazardous operation and needs to 
+_*Disclaimer: `LocationDeleteAction` is a potentially hazardous operation and needs to 
 be done with care._
 
 
@@ -195,7 +195,7 @@ A full GS1 Location address (for example purposes) would therefore be:
 ## Transaction Payload and Execution
 [transaction payload and execution]: "transactionpayloadandexecution"
 
-### Location PayLoad Transaction
+### Location Payload Transaction
 
 LocationPayload contains an action enum and the associated action payload. This 
 allows for the action payload to be dispatched to the appropriate logic.
@@ -244,9 +244,9 @@ defined in the LocationPayload.
         string location_id = 2;
     }
 
-### LocationCreateAction
+### Location Create Action
 
-LocationCreateAction adds a new location to state. The transaction should be 
+`LocationCreateAction` adds a new location to state. The transaction should be 
 submitted by an agent, which is identified by its signing key, acting on behalf 
 of the organization that corresponds to the owner in the create transaction. 
 (Organizations and agents are defined by the Pike smart contract.)
@@ -269,19 +269,19 @@ transaction is invalid.
 If all requirements are met, the transaction will be accepted and the location
 will be created in state.
 
-The inputs for LocationCreateAction must include:
+The inputs for `LocationCreateAction` must include:
 - Grid address of the Agent submitting the transaction
 - Grid address of the Organization the Location is being created for
 - Grid address of the Location Namespace Schema the location’s properties must 
 match
 - Grid address of the Location to be created
 
-The outputs for LocationCreateAction must include:
+The outputs for `LocationCreateAction` must include:
 - Grid address of the Location created
 
-### LocationUpdateAction
+### Location Update Action
 
-LocationUpdateAction updates an existing location in state. The transaction 
+`LocationUpdateAction` updates an existing location in state. The transaction 
 should be submitted by an agent, identified by its signing key, acting on behalf
 of an organization that corresponds to the owner in the location being updated.
 (Organizations and agents are defined by the Pike smart contract.)
@@ -302,14 +302,14 @@ the transaction is invalid.
 The properties in the location will be swapped for the new properties and the 
 updated location will be set in state.
 
-The inputs for LocationUpdateAction must include:
+The inputs for `LocationUpdateAction` must include:
 - Grid address of the Agent submitting the transaction
 - Grid address of the Organization the Location is being updated for
 - Grid address of the Location Namespace Schema the location’s properties must
 match
 - Grid address of the Location to be updated
 
-The outputs for LocationUpdateAction must include:
+The outputs for `LocationUpdateAction` must include:
 - Grid address of the Location updated
 
 Note: This RFC handles updates to Location master data (e.g. a Location without 
@@ -320,9 +320,9 @@ used in new transactions but can still be used when referencing earlier
 transactions. In this example, consuming logic will decide which Locations are 
 included in a transaction.
 
-### LocationDeleteAction
+### Location Delete Action
 
-LocationDeleteAction removes an existing location from state. The transaction 
+`LocationDeleteAction` removes an existing location from state. The transaction 
 should be submitted by an agent, identified by its signing key, acting on behalf
 of the organization that corresponds to the owner in the location being updated.
 (Organizations and agents are defined by the Pike smart contract.)
@@ -338,15 +338,15 @@ Validation requirements:
 belong to an organization in Pike state, otherwise the transaction is invalid.
 - The owner in the location must match the organization that the agent belongs 
 to, otherwise the transaction is invalid.
-- The agent must have the permission “can_delete_location” for the organization
+- The agent must have the permission can_delete_location for the organization
 otherwise the transaction is invalid.
 
-The inputs for LocationDeleteAction must include:
+The inputs for `LocationDeleteAction` must include:
 - Grid address of the Agent submitting the transaction
 - Grid address of the Organization the Location is being deleted for Grid 
 address of the Location to be deleted
 
-The outputs for LocationDeleteAction must include:
+The outputs for `LocationDeleteAction` must include:
 - Grid address of the Location to be deleted
 
 ### Defined GS1 Properties
@@ -433,12 +433,3 @@ should be maintained in separated database records.
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
-- GS1 attribution details regarding required/optional attributes, field type and
-minimum/maximum field values were initially sourced from the _GS1 US Data Hub | 
-Location User Guide_. We are seeking validation GS1 experts on attribute details
-that exist within this document as well as input on missing attributes and/or 
-details.
-- Does GS1 assign one or more usage types (legal entity, function, physical 
-location, digital location) to a given Location? If yes, what field is used and
-how do required/optional attribution differ for each usage type? See [GS1 Usage 
-Types](https://www.gs1.org/1/glnrules/en/guideline/230 "GS1 Usage Types").

--- a/text/0000-location.md
+++ b/text/0000-location.md
@@ -45,21 +45,22 @@ attribution (e.g. name, address, location type).
 [entities]: #entities
 
 A location has an identifier, a namespace, an owner, and one or more properties. 
-Properties are described in the ì_Defined GS1 Properties_î section of the RFC.
+Properties are described in the ‚Äú_Defined GS1 Properties_‚Äù section of the RFC.
 
 |Master Data Common Name|Attribute Name|Description|Example|
 |-----------------------|--------------|-----------|-------|
 |Location Identifier|location_id|A location is referenced using a location_id (key attribute). For GS1 locations, the location_id is a Global Location Number which is part of GS1 specifications.|"0099474000005"|
 |Namespace|location_namespace|This RFC defines a single location_namespace for GS1; a location in the GS1 location_namespace is called a GS1 location. Note that this design supports extending additional location namespaces in the future.|"01"|
-|Owner|org_id|The identifier of the organization responsible for maintaining the location. For GS1 locations, org_id is the Pike organization which claims ownership of the GS1 company prefix (via the "gs1_company_prefixes" field in the Pike records). The GLN will always start with the company prefix. The smart contract will check that the org claiming ownership lists the matching prefix in their Pike org.||
+|Owner|owner/org_id|The identifier of the organization responsible for maintaining the location. For GS1 locations, org_id is the Pike organization which claims ownership of the GS1 company prefix (via the "gs1_company_prefixes" field in the Pike records). The GLN will always start with the company prefix. The smart contract will check that the org claiming ownership lists the matching prefix in their Pike org.||
 
 
 ## Transactions
 [transactions]: #transactions
 
 In order to add Locations to state, a transaction must be used. The following 
-transactions and their execution rules are designed for the Hyperledger Sawtooth
-platform and may differ for other transaction execution platforms.
+transactions and their execution rules are designed for use with Hyperledger
+Sawtooth's Sabre smart contract engine running via Hyperledger Transact, which
+covers all currently implemented DLT backends in Grid.
 
 Locations are managed by submitting transactions to Hyperledger Grid, which will
 process them with the Grid Location smart contract. The following transactions 
@@ -77,19 +78,19 @@ be done with care._
 
 Creation of GS1 locations is restricted to agents acting on behalf of the 
 organization that is associated with the GS1 company prefix encoded in the GLN. 
-An organization must have the GS1 company prefix in the ìgs1_company_prefixesî 
-metadata field for its Pike organization. (Organization-level metadata will need
-to be implemented in Pike.) When a location is created, its owning organization 
-is stored with the location in an ìownerî field.
+Like Grid Product, an organization must have the GS1 company prefix in the 
+‚Äúgs1_company_prefixes‚Äù metadata field for its Pike organization. When a 
+location is created, its owning organization is stored with the location in an 
+‚Äúowner‚Äù field.
 
 Updates to locations are restricted to agents acting on behalf of the 
-organization stored in the locationís owner field. Only property fields can be 
+organization stored in the location‚Äôs owner field. Only property fields can be 
 updated. They are updated by providing a complete and updated list of the 
 properties, and overwrites the entire list of property values. Location_id, 
-location_namespace, and owner fields are immutable.
+location_type, and owner fields are immutable.
 
 Deletion of locations is restricted to agents acting on behalf of the 
-organization in the locationís owner field. A setting will turn off deletion 
+organization in the location‚Äôs owner field. A setting will turn off deletion 
 entirely, with the intent that it could be enabled/disabled by a Grid 
 administrator. Disabling delete is useful because external systems may have 
 references to these locations and deleting them could leave dangling references.
@@ -98,11 +99,10 @@ references to these locations and deleting them could leave dangling references.
 ## GLN Validation
 [gln validation]: #glnvalidation
 
-Creation of a reusable GLN validation function to programmatically express the 
-equation used to validate a GLN. It validates GLN format to avoid mistype errors
-similar to a credit card validation. It's implemented as an extensible function 
-such that further validation steps can be added, if needed. For details on the 
-equation see: [Check digit validation](https://www.gs1us.org/tools/check-digit-calculator "Check digit validation")
+GLN validation can reduce the opportunity for invalid data to enter the system.
+At a minimum, when GLNs are entered in clients and later processed in smart
+contracts, they will need to conform to the GLN format and the check digit
+should be correct. See [check digit calculator](https://www.gs1us.org/tools/check-digit-calculator "check digit calculator").
 
 
 
@@ -114,13 +114,32 @@ equation see: [Check digit validation](https://www.gs1us.org/tools/check-digit-c
 
 ### Location Representation
 
-The primary object stored in state is ìLocationî, which consists of a 
+The primary object stored in state is ‚ÄúLocation‚Äù, which consists of a 
 location_id (GS1 GLN), an owner (org_id compatible with Pike), and a list of 
 property name/value pairs. The properties available are defined by the Grid 
 Location Schema Transaction Family and are restricted to the fields and rules of
 the GS1 Location Property Schema. Transactions which are responsible for setting
 location state values must ensure that the properties conform with the 
 requirements of the GS1 Location Property Schema.
+
+    message Location { 
+        enum LocationType { 
+            UNSET_NAMESPACE = 0; 
+            GS1 = 1; 
+        }
+
+        // What type of location is this (GS1)
+        LocationType location_type = 1; 
+
+        // location_id is the GLN for GS1-type locations
+        string location_id = 2;
+
+        // Who owns this location (pike organization id)
+        string owner = 3;
+
+        // Properties about this location
+        repeated PropertyValue properties = 4; 
+    }
 
 The GS1 GLN is an identifier (location_id) used to identify entities or 
 locations. A GLN is the data transmitted from a data carrier (barcode, rfid, 
@@ -129,10 +148,10 @@ digit.
 
 ### Referencing Locations
 
-Locations are uniquely referenced by their location_id and location_namespace.
+Locations are uniquely referenced by their location_id and location_type.
 For GS1, locations are referenced by the GLN identifier.
 
-**Note: For the remainder of this document, ìaddressî will refer to a 
+**Note: For the remainder of this document, ‚Äúaddress‚Äù will refer to a 
 Grid/Transact address as opposed to a Street Address.**
 
 ### Location Addressing in the Merkle-Radix State System
@@ -141,24 +160,23 @@ In order to uniquely locate GS1 locations in the Merkle-Radix state system, an
 address must be constructed which identifies the storage location of the 
 Location representation.
 
-All Grid addresses are prefixed by the 6-hex-character namespace prefix ì621deeî.
+All Grid addresses are prefixed by the 6-hex-character namespace prefix ‚Äú621dee‚Äù.
 Locations are further prefixed under the Grid namespace with reserved 
-enumerations of ì04î (ì00î, ì01î, ì02î and ì03î being reserved for other 
-purposes) indicating ìLocationsî and an additional ì01î indicating ìGS1 
-Locationsî.
+enumerations of ‚Äú04‚Äù (‚Äú00‚Äù, ‚Äú01‚Äù, ‚Äú02‚Äù and ‚Äú03‚Äù being reserved for other 
+purposes) indicating ‚ÄúLocations‚Äù and an additional ‚Äú01‚Äù indicating ‚ÄúGS1 
+Locations‚Äù.
 
-Therefore, all addresses starting with ì621deeî + ì04î are Grid locations, and 
-more specifically, all addresses starting with ì621deeî + ì04î + ì01î are Grid 
+Therefore, all addresses starting with ‚Äú621dee‚Äù + ‚Äú04‚Äù are Grid locations, and 
+more specifically, all addresses starting with ‚Äú621dee‚Äù + ‚Äú04‚Äù + ‚Äú01‚Äù are Grid 
 GS1 Locations identified by a GLN.
 
-The GLN format consists of a 13-digit ìnumeric stringî that follows a similar 
+The GLN format consists of a 13-digit ‚Äúnumeric string‚Äù that follows a similar 
 structure to GTIN-13. The GLN structure first includes a GS1 Company Prefix 
 which is 7-10 digits in length and is assigned by a GS1 Member Organization. A 
 Location Reference number follows which is 2-5 digits in length and is 
 allocated by the company to a location or party. Lastly, a single digit Check 
-Digit is calculated and applied according to a GS1 algorithm.
-
-![GLN Data Format](https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcSFo3J5QULgkCWyIH3yeddRPx1H5aQusLRRq47y1n2FqTshGxs%3Ax-raw-image%3A%2F%2F%2Ff4fc819afc288cee1948ca0d40d76c3bcd56a6d270fcfeeac80fd25784eb6071&usqp=CAU)
+Digit is calculated and applied according to a GS1 algorithm. See
+[GLN Data Format](https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcSFo3J5QULgkCWyIH3yeddRPx1H5aQusLRRq47y1n2FqTshGxs%3Ax-raw-image%3A%2F%2F%2Ff4fc819afc288cee1948ca0d40d76c3bcd56a6d270fcfeeac80fd25784eb6071&usqp=CAU "GLN Data Format").
 
 After the 10-hex-characters that are consumed by the grid namespace prefix, the 
 location, and GS1 prefixes, there are 60 hex characters remaining in the address.
@@ -166,12 +184,12 @@ The 13 digits of the GLN can be left padded with 45-hex-character zeroes and
 right padded with 2-hex-character zeroes to accommodate potential future storage
 associated with the GS1 Location representation, for example:
 
-    ì621deeî + ì04î + ì01î + ì000000000000000000000000000000000000000000000î +
-    13-character ìnumeric stringî location_id + ì00î // location_id == GLN
+    ‚Äú621dee‚Äù + ‚Äú04‚Äù + ‚Äú01‚Äù + ‚Äú000000000000000000000000000000000000000000000‚Äù +
+    13-character ‚Äúnumeric string‚Äù location_id + ‚Äú00‚Äù // location_id == GLN
 
 A full GS1 Location address (for example purposes) would therefore be:
 
-    ì621dee0401000000000000000000000000000000000000000000000123456789012800î
+    ‚Äú621dee0401000000000000000000000000000000000000000000000123456789012800‚Äù
 
 
 ## Transaction Payload and Execution
@@ -218,22 +236,22 @@ Validation requirements:
 belong to an organization in Pike state, otherwise the transaction is invalid.
 - The agent must have the permission can_create_location for the organization, 
 otherwise the transaction is invalid.
-- If the location_namespace is GS1, the organization must contain a GS1 Company 
+- If the location_type is GS1, the organization must contain a GS1 Company 
 Prefix in its metadata (gs1_company_prefixes), and the prefix must match the 
 company prefix in the location_id, which is a GLN if GS1, otherwise the 
 transaction is invalid.
-- The properties must be valid for the location_namespace. For example, if the
+- The properties must be valid for the location_type. For example, if the
 location is GS1 location, its properties must only contain properties that are
 included in the GS1 Schema. If it includes a property not in the GS1 Schema the
 transaction is invalid.
 
-If all requirements are met, the transaction will be accepted, the batch will be
-written to a block, and the location will be created in state.
+If all requirements are met, the transaction will be accepted and the location
+will be created in state.
 
 The inputs for LocationCreateAction must include:
 - Grid address of the Agent submitting the transaction
 - Grid address of the Organization the Location is being created for
-- Grid address of the Location Namespace Schema the locationís properties must 
+- Grid address of the Location Namespace Schema the location‚Äôs properties must 
 match
 - Grid address of the Location to be created
 
@@ -255,7 +273,7 @@ belong to an organization in Pike state, otherwise the transaction is invalid.
 to, otherwise the transaction is invalid.
 - The agent must have the permission can_update_location for the organization, 
 otherwise the transaction is invalid.
-- The new properties must be valid for the location_namespace. For example, if 
+- The new properties must be valid for the location_type. For example, if 
 the location is a GS1 location, its properties must only contain properties that
 are included in the GS1 Schema. If it includes a property not in the GS1 Schema 
 the transaction is invalid.
@@ -266,7 +284,7 @@ updated location will be set in state.
 The inputs for LocationUpdateAction must include:
 - Grid address of the Agent submitting the transaction
 - Grid address of the Organization the Location is being updated for
-- Grid address of the Location Namespace Schema the locationís properties must
+- Grid address of the Location Namespace Schema the location‚Äôs properties must
 match
 - Grid address of the Location to be updated
 
@@ -299,7 +317,7 @@ Validation requirements:
 belong to an organization in Pike state, otherwise the transaction is invalid.
 - The owner in the location must match the organization that the agent belongs 
 to, otherwise the transaction is invalid.
-- The agent must have the permission ìcan_delete_locationî for the organization
+- The agent must have the permission ‚Äúcan_delete_location‚Äù for the organization
 otherwise the transaction is invalid.
 
 The inputs for LocationDeleteAction must include:
@@ -318,7 +336,7 @@ industries, financial/tax account information, a physical location extension, or
 digital locations and should be implemented with supplemental RFC(s).
 
 **_REQUIRED FIELDS_**
-|GS1 Common Name|GS1 Attribute Name|Description|Example|Type|Min|Max|
+|GS1 Common Name|GS1 Attribute Name|Description|Example|Data Type|Min|Max|
 |---------------|------------------|-----------|-------|----|---|---|
 |Location Name 1|locationName|The name of the facility being described.|"Sunny Fresh Foods"|STRING|1|80|
 |Description|locationDescription|Free text, 178 characters.|"A Cargill production facility dedicated to serving high-quality egg products across various markets."|STRING| | |
@@ -328,45 +346,35 @@ digital locations and should be implemented with supplemental RFC(s).
 |State or Region|stateOrRegion|The state, province, or region using the standard two-letter abbreviation specified in ISO 3166-2:1998 country subdivision code [16].|"MN"|STRING|1|3|
 |Postal Code|postalCode|The ZIP or other postal code.|"55362-8524"|STRING|1|10|
 |Country|country|Country of your location. Spell out, do not use abbreviations.|"United States"|STRING|2|80|
-|Latitude|latitude|(for fields)|"44.986656"|LAT| | |
-|Longitude|longitude|(for fields)|"-93.258133"|LONG| | |
+|Latitude & Longitude|LAT_Long| |"44.986656, -93.258133"|LAT_LONG| | |
 |Contact Name|contactName| |"Jane Doe"|STRING| | |
 |Contact Email|contactEmail| |"jane_doe@example.com"|STRING| | |
 |Contact Phone|contactPhone|The location's primary phone number. Best practice is individual with assignment duty.|"937-435-3870"|STRING|1|30|
 |Create Date|createDate|Date this location becomes active.|"06/01/2015"| | | |
 
 **_OPTIONAL FIELDS_**
-|GS1 Common Name|GS1 Attribute Name|Description|Example|Type|Min|Max|
+|GS1 Common Name|GS1 Attribute Name|Description|Example|Data Type|Min|Max|
 |---------------|------------------|-----------|-------|----|---|---|
 |Location Name 2|locationName2|A secondary facility name.|"Cargill Incorporated"|STRING|0|80|
 |Address Line 2|addressLine2|Any secondary information such as Suite, Floor, etc. The USPS address is validated if Country = United States.|"Suite 204"|STRING|0|80|
 |Address Line 3|addressLine3|Additional descriptive information that is not verified through the USPS data base. Best practice is to use AddressLine3 when there are multiple locations using the same USPS address. Examples: Billing office, cardiology lab, backroom, etc.| | | | |
 |Inactivation Date|inactivationDate|Date this location is no longer used by the information provider.|"01/15/2020"| | | |
-|Parent Location GLN|parentLocation|Used to describe a location hierarchy. Needed for every GLN except the top-level location, which does not have a parent location.|"0653114000000"|NUM|13|13|
+|Parent Location GLN|parentLocation|Used to describe a location hierarchy. Needed for every GLN except the top-level location, which does not have a parent location.|"0653114000000"|NUMBER|13|13|
 |Industry Sector|industrySector|Select one option: General, CPG, Healthcare, Foodservice.|"Foodservice"|ENUM| | |
 |Supply Chain Role|role|Available options are based on the selected Industry Sector for this GLN. General: Manufacturer, Solutions Provider, Undefined. CPG: Manufacturer, Solutions Provider, Undefined. Healthcare: Distributor, Provider, Supplier, Undefined. Foodservice: 3rd Party, Warehouse, Distributor, Independent Operator, Manufacturer, Operator.|"Manufacturer"|ENUM| | |
-|Information Provider GLN|informationProviderGLN|The entity providing this information. Usually points to the primary business GLN listed in the spreadsheet or database.|GS1 US, Inc. "0614141000005"|NUM| | |
+|Information Provider GLN|informationProviderGLN|The entity providing this information. Usually points to the primary business GLN listed in the spreadsheet or database.|GS1 US, Inc. "0614141000005"|NUMBER| | |
 |GDSN GLN Type|GDSNGLNType|Multiple types allowed. Options include: Brand Owner GLN, Manufacturer GLN, Recipient Provider GLN, Source Provider GLN, Information Provider GLN.|"Brand Owner GLN"|ENUM|15|34|
-|Replaced GLN|replaced GLN|The GLN assigned to this location previously, if any.|"1234567890128"|NUM|13|13|
+|Replaced GLN|replaced GLN|The GLN assigned to this location previously, if any.|"1234567890128"|NUMBER|13|13|
 
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-Each GLN is derived from three components. A GS1 Global Company Prefix (which 
-also identifies the owner of the GLN), a location reference number, and a check 
-digit. This RFC duplicates the organization identification with a Grid-specific 
-owner field to tie the location to organizations managed in Pike. In the future,
-it may be good to use the GLNís organizational identifier directly.
-
-Currently, Pike does not provide a place to store a GS1 Company Prefix, and the
-permissions around who is authorized to provide this prefix is complicated and
-not a direct extension of how Pike currently works. As such it is out of the 
-scope of this RFC. 
-
-Instead, Pikeís organization definition will be extended to include metadata, 
-similar to Agentís metadata. Metadata is a Key,Value store of arbitrary data.
-The GS1 Company Prefix will be stored in the metadata under ìgs1_company_prefixî.
+Many of the approaches taken here are similar or the same as the approach 
+taken with Grid Product. Thus, many of the drawbacks mentioned in the Grid 
+Product RFC that haven't yet been addressed will apply to Grid Location as well.
+This RFC intentionally re-uses the current structure where possible as 
+cross-cutting enhancements would be better in separate RFCs.
 
 This implementation does not account for transfer-of-ownership scenarios 
 (mergers, acquisitions), and should be implemented as a supplemental RFC at a 
@@ -384,7 +392,7 @@ in the future, addressing items such as:
 - facility specification (operating hours, time zone)
 - digital locations (network address, Production/Test/Development)
 
-Note from GS1: GLNs and GTINs are formed from an organizationís GS1 Company 
+Note from GS1: GLNs and GTINs are formed from an organization‚Äôs GS1 Company 
 Prefix which means the numbering sequence is identical. As such, GLNs and GTINs
 should be maintained in separated database records.
 
@@ -405,5 +413,5 @@ that exist within this document as well as input on missing attributes and/or
 details.
 - Does GS1 assign one or more usage types (legal entity, function, physical 
 location, digital location) to a given Location? If yes, what field is used and
-how do required/optional attribution differ for each usage type? GS1 Usage 
-Types: https://www.gs1.org/1/glnrules/en/guideline/230
+how do required/optional attribution differ for each usage type? See [GS1 Usage 
+Types[(https://www.gs1.org/1/glnrules/en/guideline/230 "GS1 Usage Types").

--- a/text/0000-location.md
+++ b/text/0000-location.md
@@ -1,0 +1,409 @@
+- Feature Name: Location
+- Start Date: 2020-07-29
+- RFC PR: 
+- Hyperledger Grid Issue: 
+
+# Summary
+[summary]: #summary
+
+This RFC proposes a generic and extensible framework for a Hyperledger Grid 
+Location entity as well as a more specific - and fully encapsulated - GS1 
+compliant Location. GS1 is a widely used data standard in enterprises and, given 
+that positioning and familiarity, Grid support feels natural. Additional 
+implementations of Location for specialized industries or use cases may derive 
+from or extend this implementation.
+
+This Grid Location proposal is specific to physical locations within a supply 
+chain. The GS1 General Specification defines a physical location as a site (an area,
+a structure or group of structures) or an area within the site where something 
+was, is, or will be located. For example: A label attached to a loading dock or 
+to a shelf location in a warehouse. Legal entities, functions and digital 
+locations are out of scope for our initial design and should be addressed in 
+supplemental RFC(s).
+
+# Motivation
+[motivation]: #motivation
+
+The Grid Location implementation is designed for sharing location master data 
+between participants. Location is a near universal concept within supply chain 
+solutions and would naturally be one of the highest areas of re-use across Grid 
+applications. The identification of where a physical location exists (and thus 
+where a business transaction occurs) is a foundational element that will enable 
+a wide host of distributed supply chain and commerce solutions. The design will 
+address use cases such as:
+
+- the inclusion of Location within business transactions (e.g. track and trace 
+events, inventory and warehouse management, point of sale, network optimization).
+- the enrichment of UX experiences by the inclusion of additional Location 
+attribution (e.g. name, address, location type).
+
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+## Entities
+[entities]: #entities
+
+A location has an identifier, a namespace, an owner, and one or more properties. 
+Properties are described in the “_Defined GS1 Properties_” section of the RFC.
+
+|Master Data Common Name|Attribute Name|Description|Example|
+|-----------------------|--------------|-----------|-------|
+|Location Identifier|location_id|A location is referenced using a location_id (key attribute). For GS1 locations, the location_id is a Global Location Number which is part of GS1 specifications.|"0099474000005"|
+|Namespace|location_namespace|This RFC defines a single location_namespace for GS1; a location in the GS1 location_namespace is called a GS1 location. Note that this design supports extending additional location namespaces in the future.|"01"|
+|Owner|org_id|The identifier of the organization responsible for maintaining the location. For GS1 locations, org_id is the Pike organization which claims ownership of the GS1 company prefix (via the "gs1_company_prefixes" field in the Pike records). The GLN will always start with the company prefix. The smart contract will check that the org claiming ownership lists the matching prefix in their Pike org.||
+
+
+## Transactions
+[transactions]: #transactions
+
+In order to add Locations to state, a transaction must be used. The following 
+transactions and their execution rules are designed for the Hyperledger Sawtooth
+platform and may differ for other transaction execution platforms.
+
+Locations are managed by submitting transactions to Hyperledger Grid, which will
+process them with the Grid Location smart contract. The following transactions 
+are supported:
+- LocationCreate - create a Location and store it in state.
+- LocationUpdate - update (replace) the properties of a Location already in state.
+- LocationDelete - remove a Location from state.
+ 
+_*Disclaimer: LocationDelete is a potentially hazardous operation and needs to 
+be done with care._
+
+
+## Permissions
+[permissions]: #permissions
+
+Creation of GS1 locations is restricted to agents acting on behalf of the 
+organization that is associated with the GS1 company prefix encoded in the GLN. 
+An organization must have the GS1 company prefix in the “gs1_company_prefixes” 
+metadata field for its Pike organization. (Organization-level metadata will need
+to be implemented in Pike.) When a location is created, its owning organization 
+is stored with the location in an “owner” field.
+
+Updates to locations are restricted to agents acting on behalf of the 
+organization stored in the location’s owner field. Only property fields can be 
+updated. They are updated by providing a complete and updated list of the 
+properties, and overwrites the entire list of property values. Location_id, 
+location_namespace, and owner fields are immutable.
+
+Deletion of locations is restricted to agents acting on behalf of the 
+organization in the location’s owner field. A setting will turn off deletion 
+entirely, with the intent that it could be enabled/disabled by a Grid 
+administrator. Disabling delete is useful because external systems may have 
+references to these locations and deleting them could leave dangling references.
+
+
+## GLN Validation
+[gln validation]: #glnvalidation
+
+Creation of a reusable GLN validation function to programmatically express the 
+equation used to validate a GLN. It validates GLN format to avoid mistype errors
+similar to a credit card validation. It's implemented as an extensible function 
+such that further validation steps can be added, if needed. For details on the 
+equation see: [Check digit validation](https://www.gs1us.org/tools/check-digit-calculator "Check digit validation")
+
+
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+## State
+[state]: #state
+
+### Location Representation
+
+The primary object stored in state is “Location”, which consists of a 
+location_id (GS1 GLN), an owner (org_id compatible with Pike), and a list of 
+property name/value pairs. The properties available are defined by the Grid 
+Location Schema Transaction Family and are restricted to the fields and rules of
+the GS1 Location Property Schema. Transactions which are responsible for setting
+location state values must ensure that the properties conform with the 
+requirements of the GS1 Location Property Schema.
+
+The GS1 GLN is an identifier (location_id) used to identify entities or 
+locations. A GLN is the data transmitted from a data carrier (barcode, rfid, 
+etc.) scan and is made up of a company prefix, location reference, and check 
+digit.
+
+### Referencing Locations
+
+Locations are uniquely referenced by their location_id and location_namespace.
+For GS1, locations are referenced by the GLN identifier.
+
+**Note: For the remainder of this document, “address” will refer to a 
+Grid/Transact address as opposed to a Street Address.**
+
+### Location Addressing in the Merkle-Radix State System
+
+In order to uniquely locate GS1 locations in the Merkle-Radix state system, an 
+address must be constructed which identifies the storage location of the 
+Location representation.
+
+All Grid addresses are prefixed by the 6-hex-character namespace prefix “621dee”.
+Locations are further prefixed under the Grid namespace with reserved 
+enumerations of “04” (“00”, “01”, “02” and “03” being reserved for other 
+purposes) indicating “Locations” and an additional “01” indicating “GS1 
+Locations”.
+
+Therefore, all addresses starting with “621dee” + “04” are Grid locations, and 
+more specifically, all addresses starting with “621dee” + “04” + “01” are Grid 
+GS1 Locations identified by a GLN.
+
+The GLN format consists of a 13-digit “numeric string” that follows a similar 
+structure to GTIN-13. The GLN structure first includes a GS1 Company Prefix 
+which is 7-10 digits in length and is assigned by a GS1 Member Organization. A 
+Location Reference number follows which is 2-5 digits in length and is 
+allocated by the company to a location or party. Lastly, a single digit Check 
+Digit is calculated and applied according to a GS1 algorithm.
+
+![GLN Data Format](https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcSFo3J5QULgkCWyIH3yeddRPx1H5aQusLRRq47y1n2FqTshGxs%3Ax-raw-image%3A%2F%2F%2Ff4fc819afc288cee1948ca0d40d76c3bcd56a6d270fcfeeac80fd25784eb6071&usqp=CAU)
+
+After the 10-hex-characters that are consumed by the grid namespace prefix, the 
+location, and GS1 prefixes, there are 60 hex characters remaining in the address.
+The 13 digits of the GLN can be left padded with 45-hex-character zeroes and 
+right padded with 2-hex-character zeroes to accommodate potential future storage
+associated with the GS1 Location representation, for example:
+
+    “621dee” + “04” + “01” + “000000000000000000000000000000000000000000000” +
+    13-character “numeric string” location_id + “00” // location_id == GLN
+
+A full GS1 Location address (for example purposes) would therefore be:
+
+    “621dee0401000000000000000000000000000000000000000000000123456789012800”
+
+
+## Transaction Payload and Execution
+[transaction payload and execution]: "transactionpayloadandexecution"
+
+### Location PayLoad Transaction
+
+LocationPayload contains an action enum and the associated action payload. This 
+allows for the action payload to be dispatched to the appropriate logic.
+
+Only the defined actions are available and only one action payload should be 
+defined in the LocationPayload.
+
+    message LocationPayload {        
+
+     enum Actions {
+        UNSET_ACTION = 0;
+        LOCATION_CREATE = 1;
+        LOCATION_UPDATE = 2;
+        LOCATION_DELETE = 3;
+    
+    }
+    
+    Action action = 1;
+    
+    // Approximately when transaction was submitted, as a Unix UTC timestamp
+    uint64 timestamp = 2;
+
+    LocationCreateAction location_create = 3;
+    LocationUpdateAction location_update = 4;
+    LocationDeleteAction location_delete = 5;
+    }
+
+### LocationCreateAction
+
+LocationCreateAction adds a new location to state. The transaction should be 
+submitted by an agent, which is identified by its signing key, acting on behalf 
+of the organization that corresponds to the owner in the create transaction. 
+(Organizations and agents are defined by the Pike smart contract.)
+
+Validation requirements:
+- If a location with location_id already exists the transaction is invalid.
+- The signer of the transaction must be an agent in the Pike state and must 
+belong to an organization in Pike state, otherwise the transaction is invalid.
+- The agent must have the permission can_create_location for the organization, 
+otherwise the transaction is invalid.
+- If the location_namespace is GS1, the organization must contain a GS1 Company 
+Prefix in its metadata (gs1_company_prefixes), and the prefix must match the 
+company prefix in the location_id, which is a GLN if GS1, otherwise the 
+transaction is invalid.
+- The properties must be valid for the location_namespace. For example, if the
+location is GS1 location, its properties must only contain properties that are
+included in the GS1 Schema. If it includes a property not in the GS1 Schema the
+transaction is invalid.
+
+If all requirements are met, the transaction will be accepted, the batch will be
+written to a block, and the location will be created in state.
+
+The inputs for LocationCreateAction must include:
+- Grid address of the Agent submitting the transaction
+- Grid address of the Organization the Location is being created for
+- Grid address of the Location Namespace Schema the location’s properties must 
+match
+- Grid address of the Location to be created
+
+The outputs for LocationCreateAction must include:
+- Grid address of the Location created
+
+### LocationCreateAction
+
+LocationUpdateAction updates an existing location in state. The transaction 
+should be submitted by an agent, identified by its signing key, acting on behalf
+of an organization that corresponds to the owner in the location being updated.
+(Organizations and agents are defined by the Pike smart contract.)
+
+Validation requirements:
+- If a location with location_id does not exist the transaction is invalid.
+- The signer of the transaction must be an agent in the Pike state and must 
+belong to an organization in Pike state, otherwise the transaction is invalid.
+- The owner in the location must match the organization that the agent belongs 
+to, otherwise the transaction is invalid.
+- The agent must have the permission can_update_location for the organization, 
+otherwise the transaction is invalid.
+- The new properties must be valid for the location_namespace. For example, if 
+the location is a GS1 location, its properties must only contain properties that
+are included in the GS1 Schema. If it includes a property not in the GS1 Schema 
+the transaction is invalid.
+
+The properties in the location will be swapped for the new properties and the 
+updated location will be set in state.
+
+The inputs for LocationUpdateAction must include:
+- Grid address of the Agent submitting the transaction
+- Grid address of the Organization the Location is being updated for
+- Grid address of the Location Namespace Schema the location’s properties must
+match
+- Grid address of the Location to be updated
+
+The outputs for LocationUpdateAction must include:
+- Grid address of the Location updated
+
+Note: This RFC handles updates to Location master data (e.g. a Location without 
+a defined inactivationDate is updated to have a defined inactivationDate). The 
+logic that consumes Location master data will decide what records are valid for 
+its use case. For example: A Location with a defined inactivationDate cannot be 
+used in new transactions but can still be used when referencing earlier 
+transactions. In this example, consuming logic will decide which Locations are 
+included in a transaction.
+
+### LocationDeleteAction
+
+LocationDeleteAction removes an existing location from state. The transaction 
+should be submitted by an agent, identified by its signing key, acting on behalf
+of the organization that corresponds to the owner in the location being updated.
+(Organizations and agents are defined by the Pike smart contract.)
+
+If the Grid setting grid.location.allow_delete is set to false, this transaction
+is invalid. The default value for grid.location.allow_delete is true. This 
+setting is stored using the Sawtooth Settings smart contract, more information
+can be found here.
+
+Validation requirements:
+- If a location with location_id does not exist the transaction is invalid.
+- The signer of the transaction must be an agent in the Pike state and must 
+belong to an organization in Pike state, otherwise the transaction is invalid.
+- The owner in the location must match the organization that the agent belongs 
+to, otherwise the transaction is invalid.
+- The agent must have the permission “can_delete_location” for the organization
+otherwise the transaction is invalid.
+
+The inputs for LocationDeleteAction must include:
+- Grid address of the Agent submitting the transaction
+- Grid address of the Organization the Location is being deleted for Grid 
+address of the Location to be deleted
+
+The outputs for LocationDeleteAction must include:
+- Grid address of the Location to be deleted
+
+### Defined GS1 Properties
+
+This Location RFC defines required and optional attributes for GS1 Locations 
+(see table below). This implementation does not include attribution for specific
+industries, financial/tax account information, a physical location extension, or
+digital locations and should be implemented with supplemental RFC(s).
+
+**_REQUIRED FIELDS_**
+|GS1 Common Name|GS1 Attribute Name|Description|Example|Type|Min|Max|
+|---------------|------------------|-----------|-------|----|---|---|
+|Location Name 1|locationName|The name of the facility being described.|"Sunny Fresh Foods"|STRING|1|80|
+|Description|locationDescription|Free text, 178 characters.|"A Cargill production facility dedicated to serving high-quality egg products across various markets."|STRING| | |
+|Location Type|locationType|Multiple types allowed. All Suppliers: Org Entity, Order From, Remit To, Ship To. Healthcare Providers: Bill To, Deliver To, Order By, Order From, Org Entity, Paid By, Recall, Remit To, Ship From, Ship To.|"Ship From"|ENUM|7|48|
+|Address Line 1|addressLine1|The primary street address for your location. The USPS address is validated if Country = United States.| "206 W 4th Street"|STRING|1|80|
+|City|city|Name of the city of your location. The USPS address is validated if Country = United States.|"Monticello"|STRING|1|35|
+|State or Region|stateOrRegion|The state, province, or region using the standard two-letter abbreviation specified in ISO 3166-2:1998 country subdivision code [16].|"MN"|STRING|1|3|
+|Postal Code|postalCode|The ZIP or other postal code.|"55362-8524"|STRING|1|10|
+|Country|country|Country of your location. Spell out, do not use abbreviations.|"United States"|STRING|2|80|
+|Latitude|latitude|(for fields)|"44.986656"|LAT| | |
+|Longitude|longitude|(for fields)|"-93.258133"|LONG| | |
+|Contact Name|contactName| |"Jane Doe"|STRING| | |
+|Contact Email|contactEmail| |"jane_doe@example.com"|STRING| | |
+|Contact Phone|contactPhone|The location's primary phone number. Best practice is individual with assignment duty.|"937-435-3870"|STRING|1|30|
+|Create Date|createDate|Date this location becomes active.|"06/01/2015"| | | |
+
+**_OPTIONAL FIELDS_**
+|GS1 Common Name|GS1 Attribute Name|Description|Example|Type|Min|Max|
+|---------------|------------------|-----------|-------|----|---|---|
+|Location Name 2|locationName2|A secondary facility name.|"Cargill Incorporated"|STRING|0|80|
+|Address Line 2|addressLine2|Any secondary information such as Suite, Floor, etc. The USPS address is validated if Country = United States.|"Suite 204"|STRING|0|80|
+|Address Line 3|addressLine3|Additional descriptive information that is not verified through the USPS data base. Best practice is to use AddressLine3 when there are multiple locations using the same USPS address. Examples: Billing office, cardiology lab, backroom, etc.| | | | |
+|Inactivation Date|inactivationDate|Date this location is no longer used by the information provider.|"01/15/2020"| | | |
+|Parent Location GLN|parentLocation|Used to describe a location hierarchy. Needed for every GLN except the top-level location, which does not have a parent location.|"0653114000000"|NUM|13|13|
+|Industry Sector|industrySector|Select one option: General, CPG, Healthcare, Foodservice.|"Foodservice"|ENUM| | |
+|Supply Chain Role|role|Available options are based on the selected Industry Sector for this GLN. General: Manufacturer, Solutions Provider, Undefined. CPG: Manufacturer, Solutions Provider, Undefined. Healthcare: Distributor, Provider, Supplier, Undefined. Foodservice: 3rd Party, Warehouse, Distributor, Independent Operator, Manufacturer, Operator.|"Manufacturer"|ENUM| | |
+|Information Provider GLN|informationProviderGLN|The entity providing this information. Usually points to the primary business GLN listed in the spreadsheet or database.|GS1 US, Inc. "0614141000005"|NUM| | |
+|GDSN GLN Type|GDSNGLNType|Multiple types allowed. Options include: Brand Owner GLN, Manufacturer GLN, Recipient Provider GLN, Source Provider GLN, Information Provider GLN.|"Brand Owner GLN"|ENUM|15|34|
+|Replaced GLN|replaced GLN|The GLN assigned to this location previously, if any.|"1234567890128"|NUM|13|13|
+
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Each GLN is derived from three components. A GS1 Global Company Prefix (which 
+also identifies the owner of the GLN), a location reference number, and a check 
+digit. This RFC duplicates the organization identification with a Grid-specific 
+owner field to tie the location to organizations managed in Pike. In the future,
+it may be good to use the GLN’s organizational identifier directly.
+
+Currently, Pike does not provide a place to store a GS1 Company Prefix, and the
+permissions around who is authorized to provide this prefix is complicated and
+not a direct extension of how Pike currently works. As such it is out of the 
+scope of this RFC. 
+
+Instead, Pike’s organization definition will be extended to include metadata, 
+similar to Agent’s metadata. Metadata is a Key,Value store of arbitrary data.
+The GS1 Company Prefix will be stored in the metadata under “gs1_company_prefix”.
+
+This implementation does not account for transfer-of-ownership scenarios 
+(mergers, acquisitions), and should be implemented as a supplemental RFC at a 
+later time.
+
+
+# Rationale and alternatives
+[alternatives]: #alternatives
+
+Starting with capturing a base location allows us to later extend the definition
+in the future, addressing items such as:
+- financial account information
+- tax registration numbers (VAT number)
+- delivery requirements or restrictions
+- facility specification (operating hours, time zone)
+- digital locations (network address, Production/Test/Development)
+
+Note from GS1: GLNs and GTINs are formed from an organization’s GS1 Company 
+Prefix which means the numbering sequence is identical. As such, GLNs and GTINs
+should be maintained in separated database records.
+
+
+# Prior art
+[prior-art]: #prior-art
+
+None.
+
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+- GS1 attribution details regarding required/optional attributes, field type and
+minimum/maximum field values were initially sourced from the _GS1 US Data Hub | 
+Location User Guide_. We are seeking validation GS1 experts on attribute details
+that exist within this document as well as input on missing attributes and/or 
+details.
+- Does GS1 assign one or more usage types (legal entity, function, physical 
+location, digital location) to a given Location? If yes, what field is used and
+how do required/optional attribution differ for each usage type? GS1 Usage 
+Types: https://www.gs1.org/1/glnrules/en/guideline/230

--- a/text/0000-location.md
+++ b/text/0000-location.md
@@ -13,13 +13,21 @@ that positioning and familiarity, Grid support feels natural. Additional
 implementations of Location for specialized industries or use cases may derive 
 from or extend this implementation.
 
-This Grid Location proposal is specific to physical locations within a supply 
-chain. The GS1 General Specification defines a physical location as a site (an area,
-a structure or group of structures) or an area within the site where something 
-was, is, or will be located. For example: A label attached to a loading dock or 
-to a shelf location in a warehouse. Legal entities, functions and digital 
-locations are out of scope for our initial design and should be addressed in 
-supplemental RFC(s).
+This Grid Location proposal may be used to uniquely identify the following
+locations (definitions and examples sourced from GS1).
+- Legal entities. Any buisness, government body, department, charity, individual
+or institution that has standing in the eyes of the law and has the capacity to
+enter into contracts. Examples: Whole companies, subsidiaries or divisions. Suppliers,
+distributors, banks, freight carriers, etc.
+- Functional entities. A specific department within a legal entity. Examples: accounting
+accounts payable, returns.
+- Physical locations. A site (an area, a structure or group of structures) or an
+area within the site where something was, is, or will be located. Examples: Retail
+store, manufacturing facility, warehouse, distribution center, dock door, floor
+number, section of floor, room, shelf, section on shelf.
+- Digital locations. An electronic (non-physical) address that is used for
+communication between computer systems. Example: ERP system.
+
 
 # Motivation
 [motivation]: #motivation
@@ -27,9 +35,9 @@ supplemental RFC(s).
 The Grid Location implementation is designed for sharing location master data 
 between participants. Location is a near universal concept within supply chain 
 solutions and would naturally be one of the highest areas of re-use across Grid 
-applications. The identification of where a physical location exists (and thus 
-where a business transaction occurs) is a foundational element that will enable 
-a wide host of distributed supply chain and commerce solutions. The design will 
+applications. The identification of where a location exists (and thus where a 
+business transaction occurs) is a foundational element that will enable a wide
+host of distributed supply chain and commerce solutions. The design will 
 address use cases such as:
 
 - the inclusion of Location within business transactions (e.g. track and trace 
@@ -49,7 +57,7 @@ Properties are described in the “_Defined GS1 Properties_” section of the RF
 
 |Master Data Common Name|Attribute Name|Description|Example|
 |-----------------------|--------------|-----------|-------|
-|Location Identifier|location_id|A location is referenced using a location_id (key attribute). For GS1 locations, the location_id is a Global Location Number which is part of GS1 specifications.|"0099474000005"|
+|Location Identifier|location_id|A location is referenced using a location_id (key attribute). For GS1 locations, the location_id is a Global Location Number (GLN) which is part of GS1 specifications.|"0099474000005"|
 |Location Namespace|location_namespace|This RFC defines a single location_namespace for GS1; a location in the GS1 location_namespace is called a GS1 location. Note that this design supports extending additional location namespaces in the future.|"01"|
 |Owner|owner/org_id|The identifier of the organization responsible for maintaining the location. For GS1 locations, org_id is the Pike organization which claims ownership of the GS1 company prefix (via the "gs1_company_prefixes" field in the Pike records). The GLN will always start with the company prefix. The smart contract will check that the org claiming ownership lists the matching prefix in their Pike org.||
 
@@ -162,8 +170,8 @@ Location representation.
 
 All Grid addresses are prefixed by the 6-hex-character namespace prefix “621dee”.
 Locations are further prefixed under the Grid namespace with reserved 
-enumerations of “04” (“00”, “01”, “02” and “03” being reserved for other 
-purposes) indicating “Locations” and an additional “01” indicating “GS1 
+enumerations of “04” (“00” = TBD, “01” = Schema, “02” = Product, and “03” = 
+Catalog) indicating “Locations” and an additional “01” indicating “GS1 
 Locations”.
 
 Therefore, all addresses starting with “621dee” + “04” are Grid locations, and 
@@ -351,12 +359,11 @@ The outputs for `LocationDeleteAction` must include:
 
 ### Defined GS1 Properties
 
-This Location RFC defines required and optional attributes (see below) for GS1
-physical locations such as manufacturing facilities, warehouses, distribution
-centers, retail stores, dock doors, etc. This implementation does not include
-attribution for specific industries, financial/tax account information, a 
-physical location extension, or digital locations and should be implemented 
-with supplemental RFC(s).
+This Location RFC defines base required and optional attributes (see below) 
+for GS1 locations. This implementation does not include attribution for 
+specific industries, financial/tax account information, etc. These fields
+should be implemented with supplemental RFC(s).
+
 
 **_REQUIRED FIELDS_**
 |GS1 Common Name|GS1 Attribute Name|Description|Example|Data Type|Min|Max|
@@ -380,23 +387,24 @@ with supplemental RFC(s).
 |---------------|------------------|-----------|-------|----|---|---|
 |Location Name 2|locationName2|A secondary facility name.|"Cargill Incorporated"|STRING|0|80|
 |Address Line 2|addressLine2|Any secondary information such as Suite, Floor, etc. The USPS address is validated if Country = United States.|"Suite 204"|STRING|0|80|
-|Address Line 3|addressLine3|Additional descriptive information that is not verified through the USPS data base. Best practice is to use AddressLine3 when there are multiple locations using the same USPS address. Examples: Billing office, cardiology lab, backroom, etc.| |STRING| | |
+|Address Line 3|addressLine3|Additional descriptive information that is not verified through the USPS data base. Best practice is to use AddressLine3 when there are multiple locations using the same USPS address. Examples: Billing office, cardiology lab, backroom, dock door, airport terminal/gate, etc.| |STRING| | |
 |Inactivation Date|inactivationDate|Date this location is no longer used by the information provider.|"01/15/2020"|DATETIME| | |
 |Parent Location GLN|parentLocation|Used to describe a location hierarchy. Needed for every GLN except the top-level location, which does not have a parent location.|"0653114000000"|NUMBER|13|13|
 |Industry Sector|industrySector|Select one option: General, CPG, Healthcare, Foodservice.|"Foodservice"|ENUM| | |
 |Supply Chain Role|role|Available options are based on the selected Industry Sector for this GLN. General: Manufacturer, Solutions Provider, Undefined. CPG: Manufacturer, Solutions Provider, Undefined. Healthcare: Distributor, Provider, Supplier, Undefined. Foodservice: 3rd Party, Warehouse, Distributor, Independent Operator, Manufacturer, Operator.|"Manufacturer"|ENUM| | |
 |Information Provider GLN|informationProviderGLN|The entity providing this information. Usually points to the primary business GLN listed in the spreadsheet or database.|GS1 US, Inc. "0614141000005"|NUMBER| | |
 |GDSN GLN Type|GDSNGLNType|Multiple types allowed. Options include: Brand Owner GLN, Manufacturer GLN, Recipient Provider GLN, Source Provider GLN, Information Provider GLN.|"Brand Owner GLN"|ENUM|15|34|
-|Replaced GLN|replaced GLN|The GLN assigned to this location previously, if any.|"1234567890128"|NUMBER|13|13|
+|Replaced GLN|replacedGLN|The GLN assigned to this location previously, if any.|"1234567890128"|NUMBER|13|13|
 
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
 Many of the approaches taken here are similar or the same as the approach 
-taken with Grid Product. Thus, many of the drawbacks mentioned in the Grid 
-Product RFC that haven't yet been addressed will apply to Grid Location as well.
-This RFC intentionally re-uses the current structure where possible as 
+taken with [Grid Product](https://github.com/hyperledger/grid-rfcs/blob/master/text/0005-product.md "Product RFC").
+Thus, many of the drawbacks mentioned in the Grid Product RFC that haven't
+yet been addressed will apply to Grid Location as well. This RFC 
+intentionally re-uses the current structure where possible as 
 cross-cutting enhancements would be better in separate RFCs.
 
 Competitive data will not be captured in location but can be extended to at a 
@@ -405,6 +413,15 @@ later time if need be. Similarly to how catalog_product extends product.
 This implementation does not account for transfer-of-ownership scenarios 
 (mergers, acquisitions), and should be implemented as a supplemental RFC at a 
 later time.
+
+This implementation does not account for the deactivation and reactivation
+of locations and should be implemented as a supplemental RFC at a later time
+(perhaps with an associated Status). For example: A 3rd party location may 
+pop up in the food supply chain space. Or services at an airport may go dark 
+due to inactivity (e.g. pandemic) and then reactivate when demand resurfaces 
+or capabilities shift. Note: this RFC does account for the inactivation of a
+location. Once inactivated, the location cannot be activated for 48 months per
+the location lifecycle.
 
 
 # Rationale and alternatives
@@ -416,13 +433,21 @@ in the future, addressing items such as:
 - tax registration numbers (VAT number)
 - delivery requirements or restrictions
 - facility specification (operating hours, time zone)
-- digital locations (network address, Production/Test/Development)
+- digital location attributes (network address, Production/Test/Development)
 
 Above we use the terminology LocationNamespace, which is used in the same manner
 as in the Product RFC, where it is called ProductNamespace. The current Product 
 codebase, however, calls this ProductType. Because “locationType” is a GS1 field,
 this RFC remains consistent with the use in the Product RFC, with the assumption
 that the Product codebase should be changed to match the original RFC in this respect.
+
+This RFC does not support the GLN extension component. According to GS1, "The GLN 
+extension is an optional GLN feature for sub-dividing a physical location according
+to rules internal to the location itself. Not all trading partners are able to 
+differentiate locations using the GLN extension component in their transactional 
+systems (e.g. order management, ERP)." Given limited transactional support, use of
+the GLN without the extension is recommended. The extension may be implemented in
+a future RFC when a use case warrants its use.
 
 Note from GS1: GLNs and GTINs are formed from an organization’s GS1 Company 
 Prefix which means the numbering sequence is identical. As such, GLNs and GTINs

--- a/text/0000-location.md
+++ b/text/0000-location.md
@@ -222,7 +222,7 @@ defined in the LocationPayload.
     }
 
     message LocationCreateAction {
-        Location.LocationType location_type = 1;
+        Location.LocationNamespace location_namespace = 1;
         string location_id = 2;
         string owner = 3;
         repeated PropertyValue properties = 4;
@@ -230,7 +230,7 @@ defined in the LocationPayload.
 
     message LocationUpdateAction {
         // Not modified. Only  used to find location object in state
-        Location.LocationType location_type = 1;
+        Location.LocationNamespace location_namespace = 1;
         // Not modified. Only  used to find location object in state
         string location_id = 2;
         // This will replace all properties currently defined
@@ -239,7 +239,7 @@ defined in the LocationPayload.
 
     message LocationDeleteAction {
         // Not modified. Only  used to find location object in state
-        Location.LocationType location_type = 1;
+        Location.LocationNamespace location_namespace = 1;
         // Not modified. Only  used to find location object in state
         string location_id = 2;
     }
@@ -351,10 +351,12 @@ The outputs for `LocationDeleteAction` must include:
 
 ### Defined GS1 Properties
 
-This Location RFC defines required and optional attributes for GS1 Locations 
-(see table below). This implementation does not include attribution for specific
-industries, financial/tax account information, a physical location extension, or
-digital locations and should be implemented with supplemental RFC(s).
+This Location RFC defines required and optional attributes (see below) for GS1
+physical locations such as manufacturing facilities, warehouses, distribution
+centers, retail stores, dock doors, etc. This implementation does not include
+attribution for specific industries, financial/tax account information, a 
+physical location extension, or digital locations and should be implemented 
+with supplemental RFC(s).
 
 **_REQUIRED FIELDS_**
 |GS1 Common Name|GS1 Attribute Name|Description|Example|Data Type|Min|Max|
@@ -396,6 +398,9 @@ taken with Grid Product. Thus, many of the drawbacks mentioned in the Grid
 Product RFC that haven't yet been addressed will apply to Grid Location as well.
 This RFC intentionally re-uses the current structure where possible as 
 cross-cutting enhancements would be better in separate RFCs.
+
+Competitive data will not be captured in location but can be extended to at a 
+later time if need be. Similarly to how catalog_product extends product.
 
 This implementation does not account for transfer-of-ownership scenarios 
 (mergers, acquisitions), and should be implemented as a supplemental RFC at a 

--- a/text/0000-location.md
+++ b/text/0000-location.md
@@ -263,6 +263,8 @@ Validation requirements:
 - If a location with location_id already exists the transaction is invalid.
 - The signer of the transaction must be an agent in the Pike state and must 
 belong to an organization in Pike state, otherwise the transaction is invalid.
+- The owner in the location must match the organization that the agent belongs 
+to, otherwise the transaction is invalid.
 - The agent must have the permission can_create_location for the organization, 
 otherwise the transaction is invalid.
 - If the location_namespace is GS1, the organization must contain a GS1 Company 

--- a/text/0000-location.md
+++ b/text/0000-location.md
@@ -414,4 +414,4 @@ details.
 - Does GS1 assign one or more usage types (legal entity, function, physical 
 location, digital location) to a given Location? If yes, what field is used and
 how do required/optional attribution differ for each usage type? See [GS1 Usage 
-Types[(https://www.gs1.org/1/glnrules/en/guideline/230 "GS1 Usage Types").
+Types](https://www.gs1.org/1/glnrules/en/guideline/230 "GS1 Usage Types").


### PR DESCRIPTION
This RFC proposes a GS1-compatible implementation of Location for Grid. This component is intended to serve as a structure for managing and sharing location data between entities in a Grid network. This location entity will be used by many other business processes and capabilities.